### PR TITLE
feat: add 'login_customer_id' support to enable Manager Account access

### DIFF
--- a/ads_mcp/coordinator.py
+++ b/ads_mcp/coordinator.py
@@ -19,6 +19,6 @@ server using `@mcp.tool` annotations, thereby 'coordinating' the bootstrapping
 of the server.
 """
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("Google Ads Server")
+mcp = MCPServer("Google Ads Server")

--- a/ads_mcp/tools/search.py
+++ b/ads_mcp/tools/search.py
@@ -26,6 +26,7 @@ def search(
     conditions: List[str] = None,
     orderings: List[str] = None,
     limit: int | str = None,
+    login_customer_id: str = None,
 ) -> List[Dict[str, Any]]:
     """Fetches data from the Google Ads API using the search method
 
@@ -36,10 +37,13 @@ def search(
         conditions: List of conditions to filter the data, combined using AND clauses
         orderings: How the data is ordered
         limit: The maximum number of rows to return
+        login_customer_id: The id of the login customer (Manager Account) if accessing a client account.
 
     """
 
-    ga_service = utils.get_googleads_service("GoogleAdsService")
+    ga_service = utils.get_googleads_service(
+        "GoogleAdsService", login_customer_id=login_customer_id
+    )
 
     query_parts = [f"SELECT {','.join(fields)} FROM {resource}"]
 
@@ -94,6 +98,10 @@ def _search_tool_description() -> str:
 ### Hint for customer_id
     should be a string of numbers without punctuation
     if presented in the form 123-456-7890 remove the hyphens and use 1234567890
+
+### Hint for login_customer_id
+    Required when accessing a client account through a Manager Account.
+    Should be the Manager Account ID (without punctuation).
 
 ### Hints for Dates
     All dates should be in the form YYYY-MM-DD and must include the dashes (-)

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -61,13 +61,16 @@ def _get_login_customer_id() -> str:
     return os.environ.get("GOOGLE_ADS_LOGIN_CUSTOMER_ID")
 
 
-def _get_googleads_client() -> GoogleAdsClient:
+def _get_googleads_client(login_customer_id: str = None) -> GoogleAdsClient:
     # Use this line if you have a google-ads.yaml file
     # client = GoogleAdsClient.load_from_storage()
+    if not login_customer_id:
+        login_customer_id = _get_login_customer_id()
+
     client = GoogleAdsClient(
         credentials=_create_credentials(),
         developer_token=_get_developer_token(),
-        login_customer_id=_get_login_customer_id(),
+        login_customer_id=login_customer_id,
     )
 
     return client
@@ -76,8 +79,14 @@ def _get_googleads_client() -> GoogleAdsClient:
 _googleads_client = _get_googleads_client()
 
 
-def get_googleads_service(serviceName: str) -> GoogleAdsServiceClient:
-    return _googleads_client.get_service(
+def get_googleads_service(
+    serviceName: str, login_customer_id: str = None
+) -> GoogleAdsServiceClient:
+    client = _googleads_client
+    if login_customer_id:
+        client = _get_googleads_client(login_customer_id)
+
+    return client.get_service(
         serviceName, interceptors=[MCPHeaderInterceptor()]
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.10"
 license = "Apache-2.0"
 dependencies = [
     "google-ads>=28.0.0",
-    "mcp[cli]>=1.2.0"
+    "mcp[cli]>=2.2.0"
 ]
 
 description = "MCP Server for Google Ads, depends on Google Ads API."

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -28,7 +28,7 @@ class TestUtils(unittest.TestCase):
     def test_format_output_value(self):
         """Tests that output values are formatted correctly."""
 
-        client = utils.get_googleads_client()
+        client = utils._get_googleads_client()
         self.assertEqual(
             utils.format_output_value(
                 CampaignStatusEnum.CampaignStatus.ENABLED


### PR DESCRIPTION
This PR adds support for the login_customer_id parameter in the search tool. This is critical for users accessing Client Accounts via a Manager Account, as the Google Ads API explicitly requires the login-customer-id header to be set for these requests.

Problem
Currently, attempting to query a client account (customer_id) while authenticated as a Manager Account results in a USER_PERMISSION_DENIED error with the message to pass a login_customer_id as part of the headers. This happens because the default client initialization uses the global configuration without the specific login-customer-id context required for hierarchy traversal. The MCPs do not currently support passing this information and this PR adds this functionality.