### PR TITLE
fix: handle proto.Message and repeated fields in format_output_value

### DIFF
--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -50,9 +50,7 @@ def _get_developer_token() -> str:
     """Returns the developer token from the environment variable GOOGLE_ADS_DEVELOPER_TOKEN."""
     dev_token = os.environ.get("GOOGLE_ADS_DEVELOPER_TOKEN")
     if dev_token is None:
-        raise ValueError(
-            "GOOGLE_ADS_DEVELOPER_TOKEN environment variable not set."
-        )
+        raise ValueError("GOOGLE_ADS_DEVELOPER_TOKEN environment variable not set.")
     return dev_token
 
 
@@ -105,8 +103,7 @@ def format_output_value(value: Any) -> Any:
 
 def format_output_row(row: proto.Message, attributes):
     return {
-        attr: format_output_value(get_nested_attr(row, attr))
-        for attr in attributes
+        attr: format_output_value(get_nested_attr(row, attr)) for attr in attributes
     }
 
 

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -95,6 +95,10 @@ def get_googleads_client():
 def format_output_value(value: Any) -> Any:
     if isinstance(value, proto.Enum):
         return value.name
+    elif isinstance(value, proto.Message):
+        return proto.Message.to_dict(value)
+    elif isinstance(value, (list, tuple)):
+        return [format_output_value(item) for item in value]
     else:
         return value
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -15,6 +15,7 @@
 """Test cases for the utils module."""
 
 import unittest
+from google.ads.googleads.v23.common.types.metrics import Metrics
 from google.ads.googleads.v23.enums.types.campaign_status import (
     CampaignStatusEnum,
 )
@@ -29,8 +30,40 @@ class TestUtils(unittest.TestCase):
         """Tests that output values are formatted correctly."""
 
         self.assertEqual(
-            utils.format_output_value(
-                CampaignStatusEnum.CampaignStatus.ENABLED
-            ),
+            utils.format_output_value(CampaignStatusEnum.CampaignStatus.ENABLED),
             "ENABLED",
         )
+
+    def test_format_output_value_proto_message(self):
+        """Tests that proto.Message values are converted to dict."""
+
+        msg = Metrics(clicks=100, impressions=1000)
+        result = utils.format_output_value(msg)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["clicks"], "100")
+        self.assertEqual(result["impressions"], "1000")
+
+    def test_format_output_value_list(self):
+        """Tests that list values are recursively formatted."""
+
+        result = utils.format_output_value([1, "hello", 3.14])
+        self.assertEqual(result, [1, "hello", 3.14])
+
+    def test_format_output_value_list_with_enums(self):
+        """Tests that lists containing enums are recursively formatted."""
+
+        result = utils.format_output_value(
+            [
+                CampaignStatusEnum.CampaignStatus.ENABLED,
+                CampaignStatusEnum.CampaignStatus.PAUSED,
+            ]
+        )
+        self.assertEqual(result, ["ENABLED", "PAUSED"])
+
+    def test_format_output_value_passthrough(self):
+        """Tests that primitive values pass through unchanged."""
+
+        self.assertEqual(utils.format_output_value("hello"), "hello")
+        self.assertEqual(utils.format_output_value(42), 42)
+        self.assertEqual(utils.format_output_value(3.14), 3.14)
+        self.assertIsNone(utils.format_output_value(None))


### PR DESCRIPTION
## Summary

Fixes #25

`format_output_value()` only handles `proto.Enum`, causing serialization errors for repeated proto message fields like `responsive_search_ad.headlines`.

## Changes

- `ads_mcp/utils.py`: Add handling for `proto.Message` (→ dict) and `list`/`tuple` (→ recursive format)

**Before:**
```
search(fields=["ad_group_ad.ad.responsive_search_ad.headlines", ...])
→ Error: Unable to serialize unknown type: RepeatedCompositeContainer
```

**After:**
```
search(fields=["ad_group_ad.ad.responsive_search_ad.headlines", ...])
→ [{"text": "Try Our Product Today", "pinned_field": "UNSPECIFIED"}, ...]
```