### PR TITLE
Add write capabilities: campaigns, ad groups, ads, keywords, assets, and PMax support

### DIFF
--- a/ads_mcp/server.py
+++ b/ads_mcp/server.py
@@ -20,7 +20,17 @@ from ads_mcp.coordinator import mcp
 # object, even though they are not directly used in this file.
 # The `# noqa: F401` comment tells the linter to ignore the "unused import"
 # warning.
-from ads_mcp.tools import search, core, get_resource_metadata  # noqa: F401
+from ads_mcp.tools import (
+    search,
+    core,
+    get_resource_metadata,
+    campaigns,
+    ad_groups,
+    ads_keywords,
+    assets,
+    asset_links,
+    asset_groups,
+)  # noqa: F401
 from ads_mcp.resources import (
     discovery,
     metrics,

--- a/ads_mcp/tools/ad_groups.py
+++ b/ads_mcp/tools/ad_groups.py
@@ -1,0 +1,124 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for creating and managing ad groups via the MCP server."""
+
+from typing import Dict, Any, Optional
+from ads_mcp.coordinator import mcp
+import ads_mcp.utils as utils
+
+
+@mcp.tool()
+def create_ad_group(
+    customer_id: str,
+    campaign_id: str,
+    name: str,
+    cpc_bid_micros: int = 1000000,
+    ad_group_type: str = "SEARCH_STANDARD",
+    status: str = "ENABLED",
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a new ad group within a campaign.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        campaign_id: The ID of the campaign to add the ad group to.
+        name: The name for the new ad group.
+        cpc_bid_micros: Default max CPC bid in micros (e.g., 1000000 = $1.00). Default: 1000000.
+        ad_group_type: Ad group type. One of: SEARCH_STANDARD, DISPLAY_STANDARD, SHOPPING_PRODUCT_ADS, VIDEO_BUMPER, VIDEO_TRUE_VIEW_IN_STREAM. Default: SEARCH_STANDARD.
+        status: Initial status. One of: ENABLED, PAUSED. Default: ENABLED.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created ad group resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ad_group_service = client.get_service("AdGroupService")
+    campaign_service = client.get_service("CampaignService")
+
+    ad_group_operation = client.get_type("AdGroupOperation")
+    ad_group = ad_group_operation.create
+    ad_group.name = name
+    ad_group.campaign = campaign_service.campaign_path(customer_id, campaign_id)
+    ad_group.cpc_bid_micros = cpc_bid_micros
+
+    # Set ad group type
+    type_enum = client.enums.AdGroupTypeEnum
+    ad_group.type_ = getattr(type_enum, ad_group_type)
+
+    # Set status
+    status_enum = client.enums.AdGroupStatusEnum
+    ad_group.status = getattr(status_enum, status)
+
+    response = ad_group_service.mutate_ad_groups(
+        customer_id=customer_id, operations=[ad_group_operation]
+    )
+
+    return {
+        "ad_group_resource_name": response.results[0].resource_name,
+        "message": f"Ad group '{name}' created successfully in campaign {campaign_id}.",
+    }
+
+
+@mcp.tool()
+def update_ad_group(
+    customer_id: str,
+    ad_group_id: str,
+    name: Optional[str] = None,
+    status: Optional[str] = None,
+    cpc_bid_micros: Optional[int] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Updates an existing ad group's settings.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        ad_group_id: The ID of the ad group to update.
+        name: New ad group name. Optional.
+        status: New status. One of: ENABLED, PAUSED, REMOVED. Optional.
+        cpc_bid_micros: New default max CPC bid in micros. Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the updated resource name and confirmation message.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ad_group_service = client.get_service("AdGroupService")
+    ad_group_operation = client.get_type("AdGroupOperation")
+    ad_group = ad_group_operation.update
+    ad_group.resource_name = ad_group_service.ad_group_path(
+        customer_id, ad_group_id
+    )
+
+    if name is not None:
+        ad_group.name = name
+    if status is not None:
+        status_enum = client.enums.AdGroupStatusEnum
+        ad_group.status = getattr(status_enum, status)
+    if cpc_bid_micros is not None:
+        ad_group.cpc_bid_micros = cpc_bid_micros
+
+    client.copy_from(
+        ad_group_operation.update_mask,
+        utils.create_field_mask(ad_group),
+    )
+
+    response = ad_group_service.mutate_ad_groups(
+        customer_id=customer_id, operations=[ad_group_operation]
+    )
+
+    return {
+        "ad_group_resource_name": response.results[0].resource_name,
+        "message": f"Ad group {ad_group_id} updated successfully.",
+    }

--- a/ads_mcp/tools/ads_keywords.py
+++ b/ads_mcp/tools/ads_keywords.py
@@ -449,3 +449,124 @@ def add_negative_keywords(
             f"added to campaign {campaign_id}."
         ),
     }
+
+
+@mcp.tool()
+def set_geo_targets(
+    customer_id: str,
+    campaign_id: str,
+    location_ids: List[int],
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Sets geo targeting for a campaign by adding location criteria.
+
+    Common location IDs (Google Ads geo target constants):
+        US=2840, UK=2826, Canada=2124, Australia=2036,
+        India=2356, Singapore=2702, UAE=2784,
+        Germany=2276, France=2250
+
+    Find more IDs at:
+    https://developers.google.com/google-ads/api/data/geotargets
+
+    Args:
+        customer_id: The Google Ads customer ID.
+        campaign_id: The ID of the campaign.
+        location_ids: List of geo target constant IDs.
+        login_customer_id: Optional manager account ID.
+
+    Returns:
+        Dictionary with created location criteria.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    service = client.get_service("CampaignCriterionService")
+    campaign_service = client.get_service("CampaignService")
+
+    operations = []
+    for loc_id in location_ids:
+        operation = client.get_type("CampaignCriterionOperation")
+        criterion = operation.create
+        criterion.campaign = campaign_service.campaign_path(
+            customer_id, campaign_id
+        )
+        criterion.location.geo_target_constant = f"geoTargetConstants/{loc_id}"
+        operations.append(operation)
+
+    response = service.mutate_campaign_criteria(
+        customer_id=customer_id, operations=operations
+    )
+
+    return {
+        "location_resource_names": [r.resource_name for r in response.results],
+        "locations_added": len(response.results),
+        "message": (
+            f"{len(response.results)} geo target(s) "
+            f"added to campaign {campaign_id}."
+        ),
+    }
+
+
+@mcp.tool()
+def set_ad_schedule(
+    customer_id: str,
+    campaign_id: str,
+    schedules: List[Dict[str, Any]],
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Sets ad schedule (day/hour targeting) for a campaign.
+
+    Controls which days and hours ads are shown.
+
+    Args:
+        customer_id: The Google Ads customer ID.
+        campaign_id: The ID of the campaign.
+        schedules: List of schedule objects, each with:
+            - day_of_week: One of MONDAY, TUESDAY, WEDNESDAY,
+                THURSDAY, FRIDAY, SATURDAY, SUNDAY.
+            - start_hour: Start hour (0-23).
+            - start_minute: One of ZERO, FIFTEEN, THIRTY,
+                FORTY_FIVE. Default: ZERO.
+            - end_hour: End hour (0-23). Use 24 for midnight.
+            - end_minute: One of ZERO, FIFTEEN, THIRTY,
+                FORTY_FIVE. Default: ZERO.
+        login_customer_id: Optional manager account ID.
+
+    Returns:
+        Dictionary with created schedule criteria.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    service = client.get_service("CampaignCriterionService")
+    campaign_service = client.get_service("CampaignService")
+
+    operations = []
+    for sched in schedules:
+        operation = client.get_type("CampaignCriterionOperation")
+        criterion = operation.create
+        criterion.campaign = campaign_service.campaign_path(
+            customer_id, campaign_id
+        )
+        day_enum = client.enums.DayOfWeekEnum
+        criterion.ad_schedule.day_of_week = getattr(
+            day_enum, sched["day_of_week"]
+        )
+        criterion.ad_schedule.start_hour = sched["start_hour"]
+        criterion.ad_schedule.end_hour = sched["end_hour"]
+
+        minute_enum = client.enums.MinuteOfHourEnum
+        start_min = sched.get("start_minute", "ZERO")
+        end_min = sched.get("end_minute", "ZERO")
+        criterion.ad_schedule.start_minute = getattr(minute_enum, start_min)
+        criterion.ad_schedule.end_minute = getattr(minute_enum, end_min)
+        operations.append(operation)
+
+    response = service.mutate_campaign_criteria(
+        customer_id=customer_id, operations=operations
+    )
+
+    return {
+        "schedule_resource_names": [r.resource_name for r in response.results],
+        "schedules_added": len(response.results),
+        "message": (
+            f"{len(response.results)} ad schedule(s) "
+            f"added to campaign {campaign_id}."
+        ),
+    }

--- a/ads_mcp/tools/ads_keywords.py
+++ b/ads_mcp/tools/ads_keywords.py
@@ -1,0 +1,451 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for creating ads and keywords via the MCP server."""
+
+from typing import Dict, Any, List, Optional
+from mcp.server.fastmcp import Context
+from ads_mcp.coordinator import mcp
+import ads_mcp.utils as utils
+
+
+@mcp.tool()
+def create_responsive_search_ad(
+    customer_id: str,
+    ad_group_id: str,
+    headlines: List[str],
+    descriptions: List[str],
+    final_url: str,
+    path1: Optional[str] = None,
+    path2: Optional[str] = None,
+    status: str = "ENABLED",
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a responsive search ad in an ad group.
+
+    Responsive search ads allow you to provide multiple headlines and descriptions,
+    and Google Ads will automatically test different combinations.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        ad_group_id: The ID of the ad group to add the ad to.
+        headlines: List of headline texts (min 3, max 15). Each headline max 30 characters.
+        descriptions: List of description texts (min 2, max 4). Each description max 90 characters.
+        final_url: The landing page URL for the ad.
+        path1: First URL path text (max 15 characters). Optional.
+        path2: Second URL path text (max 15 characters). Optional.
+        status: Ad status. One of: ENABLED, PAUSED. Default: ENABLED.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created ad resource name.
+    """
+    if len(headlines) < 3:
+        raise ValueError("At least 3 headlines are required.")
+    if len(headlines) > 15:
+        raise ValueError("Maximum 15 headlines allowed.")
+    if len(descriptions) < 2:
+        raise ValueError("At least 2 descriptions are required.")
+    if len(descriptions) > 4:
+        raise ValueError("Maximum 4 descriptions allowed.")
+
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ad_group_ad_service = client.get_service("AdGroupAdService")
+    ad_group_service = client.get_service("AdGroupService")
+
+    ad_group_ad_operation = client.get_type("AdGroupAdOperation")
+    ad_group_ad = ad_group_ad_operation.create
+    ad_group_ad.ad_group = ad_group_service.ad_group_path(
+        customer_id, ad_group_id
+    )
+
+    # Set status
+    status_enum = client.enums.AdGroupAdStatusEnum
+    ad_group_ad.status = getattr(status_enum, status)
+
+    # Set up responsive search ad
+    ad = ad_group_ad.ad
+    ad.final_urls.append(final_url)
+
+    for headline_text in headlines:
+        ad_text_asset = client.get_type("AdTextAsset")
+        ad_text_asset.text = headline_text
+        ad.responsive_search_ad.headlines.append(ad_text_asset)
+
+    for description_text in descriptions:
+        ad_text_asset = client.get_type("AdTextAsset")
+        ad_text_asset.text = description_text
+        ad.responsive_search_ad.descriptions.append(ad_text_asset)
+
+    if path1:
+        ad.responsive_search_ad.path1 = path1
+    if path2:
+        ad.responsive_search_ad.path2 = path2
+
+    response = ad_group_ad_service.mutate_ad_group_ads(
+        customer_id=customer_id, operations=[ad_group_ad_operation]
+    )
+
+    return {
+        "ad_resource_name": response.results[0].resource_name,
+        "message": f"Responsive search ad created successfully in ad group {ad_group_id}.",
+    }
+
+
+@mcp.tool()
+def add_keywords(
+    customer_id: str,
+    ad_group_id: str,
+    keywords: List[Dict[str, str]],
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Adds keywords to an ad group.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        ad_group_id: The ID of the ad group to add keywords to.
+        keywords: List of keyword objects, each with:
+            - text: The keyword text (e.g., "buy shoes online").
+            - match_type: One of: EXACT, PHRASE, BROAD. Default: BROAD.
+            - cpc_bid_micros: Optional CPC bid in micros for this keyword.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with created keyword resource names and count.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ad_group_criterion_service = client.get_service("AdGroupCriterionService")
+    ad_group_service = client.get_service("AdGroupService")
+
+    operations = []
+    for kw in keywords:
+        operation = client.get_type("AdGroupCriterionOperation")
+        criterion = operation.create
+        criterion.ad_group = ad_group_service.ad_group_path(
+            customer_id, ad_group_id
+        )
+        criterion.status = client.enums.AdGroupCriterionStatusEnum.ENABLED
+
+        # Set keyword
+        criterion.keyword.text = kw["text"]
+        match_type = kw.get("match_type", "BROAD")
+        match_type_enum = client.enums.KeywordMatchTypeEnum
+        criterion.keyword.match_type = getattr(match_type_enum, match_type)
+
+        # Set optional bid
+        if "cpc_bid_micros" in kw:
+            criterion.cpc_bid_micros = int(kw["cpc_bid_micros"])
+
+        operations.append(operation)
+
+    response = ad_group_criterion_service.mutate_ad_group_criteria(
+        customer_id=customer_id, operations=operations
+    )
+
+    return {
+        "keyword_resource_names": [
+            result.resource_name for result in response.results
+        ],
+        "keywords_added": len(response.results),
+        "message": f"{len(response.results)} keyword(s) added to ad group {ad_group_id}.",
+    }
+
+
+@mcp.tool()
+def update_ad_status(
+    customer_id: str,
+    ad_group_id: str,
+    ad_id: str,
+    status: str,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, str]:
+    """Enables, pauses, or removes an ad.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        ad_group_id: The ID of the ad group containing the ad.
+        ad_id: The ID of the ad to update.
+        status: New status. One of: ENABLED, PAUSED, REMOVED.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the updated resource name and confirmation message.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ad_group_ad_service = client.get_service("AdGroupAdService")
+    ad_group_ad_operation = client.get_type("AdGroupAdOperation")
+    ad_group_ad = ad_group_ad_operation.update
+    ad_group_ad.resource_name = ad_group_ad_service.ad_group_ad_path(
+        customer_id, ad_group_id, ad_id
+    )
+
+    status_enum = client.enums.AdGroupAdStatusEnum
+    ad_group_ad.status = getattr(status_enum, status)
+
+    client.copy_from(
+        ad_group_ad_operation.update_mask,
+        utils.create_field_mask(ad_group_ad),
+    )
+
+    response = ad_group_ad_service.mutate_ad_group_ads(
+        customer_id=customer_id, operations=[ad_group_ad_operation]
+    )
+
+    return {
+        "ad_resource_name": response.results[0].resource_name,
+        "message": f"Ad {ad_id} status set to {status}.",
+    }
+
+
+@mcp.tool()
+def update_keyword(
+    customer_id: str,
+    ad_group_id: str,
+    criterion_id: str,
+    status: Optional[str] = None,
+    cpc_bid_micros: Optional[int] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, str]:
+    """Updates a keyword's status or bid.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        ad_group_id: The ID of the ad group containing the keyword.
+        criterion_id: The criterion ID of the keyword.
+        status: New status. One of: ENABLED, PAUSED, REMOVED. Optional.
+        cpc_bid_micros: New CPC bid in micros. Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the updated resource name and confirmation message.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    criterion_service = client.get_service("AdGroupCriterionService")
+    operation = client.get_type("AdGroupCriterionOperation")
+    criterion = operation.update
+    criterion.resource_name = criterion_service.ad_group_criterion_path(
+        customer_id, ad_group_id, criterion_id
+    )
+
+    if status is not None:
+        status_enum = client.enums.AdGroupCriterionStatusEnum
+        criterion.status = getattr(status_enum, status)
+    if cpc_bid_micros is not None:
+        criterion.cpc_bid_micros = cpc_bid_micros
+
+    client.copy_from(
+        operation.update_mask,
+        utils.create_field_mask(criterion),
+    )
+
+    response = criterion_service.mutate_ad_group_criteria(
+        customer_id=customer_id, operations=[operation]
+    )
+
+    return {
+        "keyword_resource_name": response.results[0].resource_name,
+        "message": f"Keyword {criterion_id} updated successfully.",
+    }
+
+
+@mcp.tool()
+async def remove_ad(
+    customer_id: str,
+    ad_group_id: str,
+    ad_id: str,
+    login_customer_id: Optional[str] = None,
+    ctx: Context = None,
+) -> Dict[str, str]:
+    """Permanently removes an ad from an ad group.
+
+    Use this to delete disapproved, old, or unwanted ads. This action
+    cannot be undone — the ad will be permanently removed.
+    Requires user confirmation via interactive elicitation before proceeding.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        ad_group_id: The ID of the ad group containing the ad.
+        ad_id: The ID of the ad to remove.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with confirmation message.
+    """
+    from pydantic import BaseModel, Field
+
+    class Confirmation(BaseModel):
+        confirm: bool = Field(
+            description="Set to true to permanently remove this ad."
+        )
+
+    # Ask user for confirmation via elicitation
+    # Falls back gracefully if client doesn't support elicitation
+    try:
+        result = await ctx.elicit(
+            message=(
+                f"⚠️ DESTRUCTIVE ACTION: Permanently remove "
+                f"ad {ad_id} from ad group {ad_group_id} "
+                f"in account {customer_id}? "
+                f"This cannot be undone."
+            ),
+            schema=Confirmation,
+        )
+        if result.action != "accept" or not result.data.confirm:
+            return {"message": "Ad removal cancelled by user."}
+    except Exception:
+        # Client doesn't support elicitation yet, proceed
+        pass
+
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    service = client.get_service("AdGroupAdService")
+
+    resource_name = service.ad_group_ad_path(customer_id, ad_group_id, ad_id)
+    operation = client.get_type("AdGroupAdOperation")
+    operation.remove = resource_name
+
+    response = service.mutate_ad_group_ads(
+        customer_id=customer_id, operations=[operation]
+    )
+
+    return {
+        "removed_resource_name": response.results[0].resource_name,
+        "message": (
+            f"Ad {ad_id} permanently removed " f"from ad group {ad_group_id}."
+        ),
+    }
+
+
+@mcp.tool()
+async def remove_keyword(
+    customer_id: str,
+    ad_group_id: str,
+    criterion_id: str,
+    login_customer_id: Optional[str] = None,
+    ctx: Context = None,
+) -> Dict[str, str]:
+    """Permanently removes a keyword from an ad group.
+
+    This action cannot be undone.
+    Requires user confirmation via interactive elicitation before proceeding.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        ad_group_id: The ID of the ad group containing the keyword.
+        criterion_id: The criterion ID of the keyword to remove.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with confirmation message.
+    """
+    from pydantic import BaseModel, Field
+
+    class Confirmation(BaseModel):
+        confirm: bool = Field(
+            description="Set to true to permanently remove this keyword."
+        )
+
+    # Ask user for confirmation via elicitation
+    # Auto-works when client supports elicitation/create method
+    try:
+        result = await ctx.elicit(
+            message=(
+                f"⚠️ DESTRUCTIVE ACTION: Permanently remove "
+                f"keyword {criterion_id} from ad group "
+                f"{ad_group_id} in account {customer_id}? "
+                f"This cannot be undone."
+            ),
+            schema=Confirmation,
+        )
+        if result.action != "accept" or not result.data.confirm:
+            return {"message": "Keyword removal cancelled by user."}
+    except Exception:
+        # Client doesn't support elicitation yet
+        pass
+
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    service = client.get_service("AdGroupCriterionService")
+
+    resource_name = service.ad_group_criterion_path(
+        customer_id, ad_group_id, criterion_id
+    )
+    operation = client.get_type("AdGroupCriterionOperation")
+    operation.remove = resource_name
+
+    response = service.mutate_ad_group_criteria(
+        customer_id=customer_id, operations=[operation]
+    )
+
+    return {
+        "removed_resource_name": response.results[0].resource_name,
+        "message": (
+            f"Keyword {criterion_id} permanently removed "
+            f"from ad group {ad_group_id}."
+        ),
+    }
+
+
+@mcp.tool()
+def add_negative_keywords(
+    customer_id: str,
+    campaign_id: str,
+    keywords: List[Dict[str, str]],
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Adds negative keywords to a campaign to block irrelevant traffic.
+
+    Negative keywords prevent your ads from showing for specific search terms.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        campaign_id: The ID of the campaign to add negative keywords to.
+        keywords: List of keyword objects, each with:
+            - text: The keyword text (e.g., "free LMS").
+            - match_type: One of: EXACT, PHRASE, BROAD. Default: BROAD.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with created negative keyword resource names.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    service = client.get_service("CampaignCriterionService")
+    campaign_service = client.get_service("CampaignService")
+
+    operations = []
+    for kw in keywords:
+        operation = client.get_type("CampaignCriterionOperation")
+        criterion = operation.create
+        criterion.campaign = campaign_service.campaign_path(
+            customer_id, campaign_id
+        )
+        criterion.negative = True
+        criterion.keyword.text = kw["text"]
+        match_type = kw.get("match_type", "BROAD")
+        match_enum = client.enums.KeywordMatchTypeEnum
+        criterion.keyword.match_type = getattr(match_enum, match_type)
+        operations.append(operation)
+
+    response = service.mutate_campaign_criteria(
+        customer_id=customer_id, operations=operations
+    )
+
+    return {
+        "negative_keyword_resource_names": [
+            r.resource_name for r in response.results
+        ],
+        "keywords_added": len(response.results),
+        "message": (
+            f"{len(response.results)} negative keyword(s) "
+            f"added to campaign {campaign_id}."
+        ),
+    }

--- a/ads_mcp/tools/asset_groups.py
+++ b/ads_mcp/tools/asset_groups.py
@@ -1,0 +1,284 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for creating and managing Performance Max asset groups via the MCP server.
+
+Performance Max campaigns require asset groups with minimum assets, and these
+must be created together in a single batch mutate request. This module handles
+that complexity.
+"""
+
+from typing import Dict, Any, List, Optional
+from mcp.server.fastmcp import Context
+from ads_mcp.coordinator import mcp
+import ads_mcp.utils as utils
+
+
+@mcp.tool()
+def create_asset_group(
+    customer_id: str,
+    campaign_id: str,
+    name: str,
+    final_url: str,
+    headline_asset_resource_names: List[str],
+    description_asset_resource_names: List[str],
+    long_headline_asset_resource_names: List[str],
+    marketing_image_asset_resource_names: List[str],
+    square_marketing_image_asset_resource_names: List[str],
+    logo_asset_resource_names: Optional[List[str]] = None,
+    youtube_video_asset_resource_names: Optional[List[str]] = None,
+    final_mobile_url: Optional[str] = None,
+    path1: Optional[str] = None,
+    path2: Optional[str] = None,
+    status: str = "ENABLED",
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates an asset group for a Performance Max campaign and links all provided assets to it.
+
+    Asset groups and their assets must be created together in a single batch request.
+    Create all required assets first using create_text_asset, create_image_asset, etc.,
+    then pass their resource names here.
+
+    Minimum asset requirements for Performance Max:
+    - At least 3 headlines (max 15)
+    - At least 2 descriptions (max 5)
+    - At least 1 long headline (max 5)
+    - At least 1 marketing image (landscape, 1200x628 recommended)
+    - At least 1 square marketing image (1200x1200 recommended)
+    - At least 1 logo (1200x1200 recommended)
+    - YouTube videos are optional but recommended
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        campaign_id: The ID of the Performance Max campaign.
+        name: Name for the asset group.
+        final_url: The landing page URL for the asset group.
+        headline_asset_resource_names: List of text asset resource names for headlines (min 3).
+        description_asset_resource_names: List of text asset resource names for descriptions (min 2).
+        long_headline_asset_resource_names: List of text asset resource names for long headlines (min 1).
+        marketing_image_asset_resource_names: List of image asset resource names for landscape images (min 1).
+        square_marketing_image_asset_resource_names: List of image asset resource names for square images (min 1).
+        logo_asset_resource_names: List of image asset resource names for logos (min 1).
+        youtube_video_asset_resource_names: List of YouTube video asset resource names. Optional.
+        final_mobile_url: Mobile landing page URL. Optional.
+        path1: First URL path text (max 15 characters). Optional.
+        path2: Second URL path text (max 15 characters). Optional.
+        status: Asset group status. One of: ENABLED, PAUSED. Default: ENABLED.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset group resource name and linked asset count.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ga_service = client.get_service("GoogleAdsService")
+    campaign_service = client.get_service("CampaignService")
+
+    operations = []
+
+    # Operation 1: Create the asset group
+    asset_group_op = client.get_type("MutateOperation")
+    asset_group = asset_group_op.asset_group_operation.create
+    asset_group.name = name
+    asset_group.campaign = campaign_service.campaign_path(
+        customer_id, campaign_id
+    )
+    asset_group.final_urls.append(final_url)
+    if final_mobile_url:
+        asset_group.final_mobile_urls.append(final_mobile_url)
+    if path1:
+        asset_group.path1 = path1
+    if path2:
+        asset_group.path2 = path2
+
+    status_enum = client.enums.AssetGroupStatusEnum
+    asset_group.status = getattr(status_enum, status)
+
+    # Use a temporary resource name for the asset group so we can reference it
+    # in subsequent operations within the same batch request
+    asset_group_temp_rn = f"customers/{customer_id}/assetGroups/-1"
+    asset_group.resource_name = asset_group_temp_rn
+
+    operations.append(asset_group_op)
+
+    # Helper to create AssetGroupAsset operations
+    def _add_asset_group_asset_op(asset_rn, field_type_name):
+        op = client.get_type("MutateOperation")
+        aga = op.asset_group_asset_operation.create
+        aga.asset_group = asset_group_temp_rn
+        aga.asset = asset_rn
+        field_type_enum = client.enums.AssetFieldTypeEnum
+        aga.field_type = getattr(field_type_enum, field_type_name)
+        operations.append(op)
+
+    # Link headlines
+    for rn in headline_asset_resource_names:
+        _add_asset_group_asset_op(rn, "HEADLINE")
+
+    # Link descriptions
+    for rn in description_asset_resource_names:
+        _add_asset_group_asset_op(rn, "DESCRIPTION")
+
+    # Link long headlines
+    for rn in long_headline_asset_resource_names:
+        _add_asset_group_asset_op(rn, "LONG_HEADLINE")
+
+    # Link marketing images (landscape)
+    for rn in marketing_image_asset_resource_names:
+        _add_asset_group_asset_op(rn, "MARKETING_IMAGE")
+
+    # Link square marketing images
+    for rn in square_marketing_image_asset_resource_names:
+        _add_asset_group_asset_op(rn, "SQUARE_MARKETING_IMAGE")
+
+    # Link logos (skip if Brand Guidelines is enabled — logos go at campaign level)
+    if logo_asset_resource_names:
+        for rn in logo_asset_resource_names:
+            _add_asset_group_asset_op(rn, "LOGO")
+
+    # Link YouTube videos if provided
+    if youtube_video_asset_resource_names:
+        for rn in youtube_video_asset_resource_names:
+            _add_asset_group_asset_op(rn, "YOUTUBE_VIDEO")
+
+    # Execute the batch mutate
+    response = ga_service.mutate(
+        customer_id=customer_id, mutate_operations=operations
+    )
+
+    # First result is the asset group, rest are asset links
+    asset_group_result = response.mutate_operation_responses[0]
+    asset_group_rn = asset_group_result.asset_group_result.resource_name
+
+    return {
+        "asset_group_resource_name": asset_group_rn,
+        "assets_linked": len(operations) - 1,
+        "message": f"Asset group '{name}' created with {len(operations) - 1} assets linked.",
+    }
+
+
+@mcp.tool()
+def add_assets_to_asset_group(
+    customer_id: str,
+    asset_group_resource_name: str,
+    assets: List[Dict[str, str]],
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Adds assets to an existing asset group.
+
+    Use this to add more assets to an asset group after it's been created.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        asset_group_resource_name: The resource name of the asset group.
+        assets: List of asset objects, each with:
+            - asset_resource_name: The resource name of the asset.
+            - field_type: One of: HEADLINE, DESCRIPTION, LONG_HEADLINE,
+                MARKETING_IMAGE, SQUARE_MARKETING_IMAGE, LOGO,
+                LANDSCAPE_LOGO, YOUTUBE_VIDEO, CALL_TO_ACTION_SELECTION.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the count of assets added.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ga_service = client.get_service("GoogleAdsService")
+
+    operations = []
+    for asset_info in assets:
+        op = client.get_type("MutateOperation")
+        aga = op.asset_group_asset_operation.create
+        aga.asset_group = asset_group_resource_name
+        aga.asset = asset_info["asset_resource_name"]
+
+        field_type_enum = client.enums.AssetFieldTypeEnum
+        aga.field_type = getattr(field_type_enum, asset_info["field_type"])
+
+        operations.append(op)
+
+    response = ga_service.mutate(
+        customer_id=customer_id, mutate_operations=operations
+    )
+
+    return {
+        "assets_added": len(response.mutate_operation_responses),
+        "message": f"{len(response.mutate_operation_responses)} asset(s) added to asset group.",
+    }
+
+
+@mcp.tool()
+async def remove_asset_from_asset_group(
+    customer_id: str,
+    asset_group_resource_name: str,
+    asset_resource_name: str,
+    field_type: str,
+    login_customer_id: Optional[str] = None,
+    ctx: Context = None,
+) -> Dict[str, str]:
+    """Removes an asset from an asset group.
+
+    Requires user confirmation via interactive elicitation before proceeding.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        asset_group_resource_name: The resource name of the asset group.
+        asset_resource_name: The resource name of the asset to remove.
+        field_type: The field type of the asset. One of: HEADLINE, DESCRIPTION,
+            LONG_HEADLINE, MARKETING_IMAGE, SQUARE_MARKETING_IMAGE, LOGO,
+            LANDSCAPE_LOGO, YOUTUBE_VIDEO, CALL_TO_ACTION_SELECTION.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with confirmation message.
+    """
+    from pydantic import BaseModel, Field
+
+    class Confirmation(BaseModel):
+        confirm: bool = Field(description="Set to true to remove this asset.")
+
+    try:
+        asset_id = asset_resource_name.split("/")[-1]
+        result = await ctx.elicit(
+            message=(
+                f"⚠️ Remove {field_type} asset {asset_id} "
+                f"from asset group? This cannot be undone."
+            ),
+            schema=Confirmation,
+        )
+        if result.action != "accept" or not result.data.confirm:
+            return {"message": "Asset removal cancelled by user."}
+    except Exception:
+        pass
+
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_group_asset_service = client.get_service("AssetGroupAssetService")
+
+    operation = client.get_type("AssetGroupAssetOperation")
+
+    # Resource name format uses the field type string name
+    asset_group_id = asset_group_resource_name.split("/")[-1]
+    asset_id = asset_resource_name.split("/")[-1]
+    resource_name = (
+        f"customers/{customer_id}/assetGroupAssets/"
+        f"{asset_group_id}~{asset_id}~{field_type}"
+    )
+    operation.remove = resource_name
+
+    response = asset_group_asset_service.mutate_asset_group_assets(
+        customer_id=customer_id, operations=[operation]
+    )
+
+    return {
+        "removed_resource_name": response.results[0].resource_name,
+        "message": "Asset removed from asset group.",
+    }

--- a/ads_mcp/tools/asset_links.py
+++ b/ads_mcp/tools/asset_links.py
@@ -1,0 +1,226 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for linking assets to campaigns and ad groups via the MCP server."""
+
+from typing import Dict, Any, List, Optional
+from mcp.server.fastmcp import Context
+from ads_mcp.coordinator import mcp
+import ads_mcp.utils as utils
+
+
+@mcp.tool()
+def link_asset_to_campaign(
+    customer_id: str,
+    campaign_id: str,
+    asset_resource_name: str,
+    field_type: str,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Links an existing asset to a campaign.
+
+    After creating an asset (sitelink, callout, etc.), use this tool to
+    attach it to a campaign so it appears with that campaign's ads.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        campaign_id: The ID of the campaign to link the asset to.
+        asset_resource_name: The resource name of the asset (from create_*_asset tools).
+        field_type: The asset field type. One of: SITELINK, CALLOUT, STRUCTURED_SNIPPET,
+            CALL, PROMOTION, PRICE, LEAD_FORM, MOBILE_APP, HOTEL_CALLOUT, IMAGE,
+            BUSINESS_NAME, BUSINESS_LOGO.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created campaign asset link resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    campaign_asset_service = client.get_service("CampaignAssetService")
+    campaign_service = client.get_service("CampaignService")
+
+    operation = client.get_type("CampaignAssetOperation")
+    campaign_asset = operation.create
+    campaign_asset.campaign = campaign_service.campaign_path(
+        customer_id, campaign_id
+    )
+    campaign_asset.asset = asset_resource_name
+
+    field_type_enum = client.enums.AssetFieldTypeEnum
+    campaign_asset.field_type = getattr(field_type_enum, field_type)
+
+    response = campaign_asset_service.mutate_campaign_assets(
+        customer_id=customer_id, operations=[operation]
+    )
+
+    return {
+        "campaign_asset_resource_name": response.results[0].resource_name,
+        "message": f"Asset linked to campaign {campaign_id} as {field_type}.",
+    }
+
+
+@mcp.tool()
+def link_asset_to_ad_group(
+    customer_id: str,
+    ad_group_id: str,
+    asset_resource_name: str,
+    field_type: str,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Links an existing asset to an ad group.
+
+    After creating an asset (sitelink, callout, etc.), use this tool to
+    attach it to an ad group so it appears with that ad group's ads.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        ad_group_id: The ID of the ad group to link the asset to.
+        asset_resource_name: The resource name of the asset (from create_*_asset tools).
+        field_type: The asset field type. One of: SITELINK, CALLOUT, STRUCTURED_SNIPPET,
+            CALL, PROMOTION, PRICE, LEAD_FORM, MOBILE_APP, HOTEL_CALLOUT, IMAGE.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created ad group asset link resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ad_group_asset_service = client.get_service("AdGroupAssetService")
+    ad_group_service = client.get_service("AdGroupService")
+
+    operation = client.get_type("AdGroupAssetOperation")
+    ad_group_asset = operation.create
+    ad_group_asset.ad_group = ad_group_service.ad_group_path(
+        customer_id, ad_group_id
+    )
+    ad_group_asset.asset = asset_resource_name
+
+    field_type_enum = client.enums.AssetFieldTypeEnum
+    ad_group_asset.field_type = getattr(field_type_enum, field_type)
+
+    response = ad_group_asset_service.mutate_ad_group_assets(
+        customer_id=customer_id, operations=[operation]
+    )
+
+    return {
+        "ad_group_asset_resource_name": response.results[0].resource_name,
+        "message": f"Asset linked to ad group {ad_group_id} as {field_type}.",
+    }
+
+
+@mcp.tool()
+def link_assets_to_customer(
+    customer_id: str,
+    asset_resource_names: List[str],
+    field_type: str,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Links assets at the customer (account) level so they apply to all campaigns.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        asset_resource_names: List of asset resource names to link.
+        field_type: The asset field type. One of: SITELINK, CALLOUT, STRUCTURED_SNIPPET,
+            CALL, PROMOTION, PRICE, LEAD_FORM, MOBILE_APP, BUSINESS_NAME, BUSINESS_LOGO.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created customer asset link resource names.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    customer_asset_service = client.get_service("CustomerAssetService")
+
+    operations = []
+    for asset_rn in asset_resource_names:
+        operation = client.get_type("CustomerAssetOperation")
+        customer_asset = operation.create
+        customer_asset.asset = asset_rn
+
+        field_type_enum = client.enums.AssetFieldTypeEnum
+        customer_asset.field_type = getattr(field_type_enum, field_type)
+
+        operations.append(operation)
+
+    response = customer_asset_service.mutate_customer_assets(
+        customer_id=customer_id, operations=operations
+    )
+
+    return {
+        "customer_asset_resource_names": [
+            result.resource_name for result in response.results
+        ],
+        "assets_linked": len(response.results),
+        "message": f"{len(response.results)} asset(s) linked at account level as {field_type}.",
+    }
+
+
+@mcp.tool()
+async def remove_campaign_asset(
+    customer_id: str,
+    campaign_id: str,
+    asset_id: str,
+    field_type: str,
+    login_customer_id: Optional[str] = None,
+    ctx: Context = None,
+) -> Dict[str, str]:
+    """Removes an asset link from a campaign.
+
+    Requires user confirmation via interactive elicitation before proceeding.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        campaign_id: The ID of the campaign.
+        asset_id: The ID of the asset to unlink.
+        field_type: The asset field type (e.g., SITELINK, CALLOUT).
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with confirmation message.
+    """
+    from pydantic import BaseModel, Field
+
+    class Confirmation(BaseModel):
+        confirm: bool = Field(description="Set to true to remove this asset.")
+
+    try:
+        result = await ctx.elicit(
+            message=(
+                f"⚠️ Remove {field_type} asset {asset_id} "
+                f"from campaign {campaign_id}?"
+            ),
+            schema=Confirmation,
+        )
+        if result.action != "accept" or not result.data.confirm:
+            return {"message": "Asset removal cancelled by user."}
+    except Exception:
+        pass
+
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    campaign_asset_service = client.get_service("CampaignAssetService")
+
+    resource_name = campaign_asset_service.campaign_asset_path(
+        customer_id, campaign_id, asset_id, field_type
+    )
+
+    operation = client.get_type("CampaignAssetOperation")
+    operation.remove = resource_name
+
+    response = campaign_asset_service.mutate_campaign_assets(
+        customer_id=customer_id, operations=[operation]
+    )
+
+    return {
+        "removed_resource_name": response.results[0].resource_name,
+        "message": (
+            f"Asset {asset_id} removed from " f"campaign {campaign_id}."
+        ),
+    }

--- a/ads_mcp/tools/assets.py
+++ b/ads_mcp/tools/assets.py
@@ -1,0 +1,595 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for creating and managing assets (sitelinks, callouts, etc.) via the MCP server."""
+
+from typing import Dict, Any, List, Optional
+from ads_mcp.coordinator import mcp
+import ads_mcp.utils as utils
+
+
+@mcp.tool()
+def create_sitelink_asset(
+    customer_id: str,
+    link_text: str,
+    final_url: str,
+    description1: Optional[str] = None,
+    description2: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a sitelink asset that can be linked to campaigns or ad groups.
+
+    Sitelinks add additional links below your ad, directing users to specific pages.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        link_text: The text displayed for the sitelink (max 25 characters).
+        final_url: The URL the sitelink directs to.
+        description1: First line of description (max 35 characters). Optional.
+        description2: Second line of description (max 35 characters). Optional.
+        start_date: Start date in YYYY-MM-DD format. Optional.
+        end_date: End date in YYYY-MM-DD format. Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    asset.sitelink_asset.link_text = link_text
+    asset.final_urls.append(final_url)
+
+    if description1:
+        asset.sitelink_asset.description1 = description1
+    if description2:
+        asset.sitelink_asset.description2 = description2
+    if start_date:
+        asset.sitelink_asset.start_date = start_date
+    if end_date:
+        asset.sitelink_asset.end_date = end_date
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Sitelink asset '{link_text}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_callout_asset(
+    customer_id: str,
+    callout_text: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a callout asset that can be linked to campaigns or ad groups.
+
+    Callouts add short snippets of text to your ad (e.g., "Free Shipping", "24/7 Support").
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        callout_text: The callout text (max 25 characters).
+        start_date: Start date in YYYY-MM-DD format. Optional.
+        end_date: End date in YYYY-MM-DD format. Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    asset.callout_asset.callout_text = callout_text
+
+    if start_date:
+        asset.callout_asset.start_date = start_date
+    if end_date:
+        asset.callout_asset.end_date = end_date
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Callout asset '{callout_text}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_structured_snippet_asset(
+    customer_id: str,
+    header: str,
+    values: List[str],
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a structured snippet asset that can be linked to campaigns or ad groups.
+
+    Structured snippets highlight specific aspects of your products/services
+    (e.g., header "Brands" with values ["Nike", "Adidas", "Puma"]).
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        header: The snippet header. One of: Amenities, Brands, Courses, Degree programs,
+            Destinations, Featured hotels, Insurance coverage, Models, Neighborhoods,
+            Service catalog, Shows, Styles, Types.
+        values: List of values for the snippet (min 3 values recommended).
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    asset.structured_snippet_asset.header = header
+    for value in values:
+        asset.structured_snippet_asset.values.append(value)
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Structured snippet asset with header '{header}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_call_asset(
+    customer_id: str,
+    country_code: str,
+    phone_number: str,
+    call_conversion_reporting_state: str = "DISABLED",
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a call asset that can be linked to campaigns or ad groups.
+
+    Call assets add a phone number to your ad, allowing users to call directly.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        country_code: Two-letter country code (e.g., "US", "GB", "IN").
+        phone_number: The phone number string.
+        call_conversion_reporting_state: One of: DISABLED, USE_ACCOUNT_LEVEL_CALL_CONVERSION_ACTION,
+            USE_RESOURCE_LEVEL_CALL_CONVERSION_ACTION. Default: DISABLED.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    asset.call_asset.country_code = country_code
+    asset.call_asset.phone_number = phone_number
+
+    reporting_enum = client.enums.CallConversionReportingStateEnum
+    asset.call_asset.call_conversion_reporting_state = getattr(
+        reporting_enum, call_conversion_reporting_state
+    )
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Call asset with phone number '{phone_number}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_image_asset(
+    customer_id: str,
+    image_source: str,
+    asset_name: str,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates an image asset from a URL or local file path.
+
+    Supports both web URLs and local file paths on the user's computer.
+
+    Recommended image sizes for Performance Max:
+    - Marketing image (landscape): 1200x628
+    - Square marketing image: 1200x1200
+    - Logo: 1200x1200
+    - Landscape logo: 1200x300
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        image_source: Either a URL (https://...) or a local file path (/path/to/image.jpg).
+        asset_name: A name for the image asset.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    import os
+
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    # Load image data from URL or local file
+    if image_source.startswith(("http://", "https://")):
+        import urllib.request
+
+        image_data = urllib.request.urlopen(image_source).read()
+    elif os.path.isfile(image_source):
+        with open(image_source, "rb") as f:
+            image_data = f.read()
+    else:
+        raise ValueError(
+            f"Image source '{image_source}' is not a valid URL or file path."
+        )
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    asset.type_ = client.enums.AssetTypeEnum.IMAGE
+    asset.name = asset_name
+    asset.image_asset.data = image_data
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Image asset '{asset_name}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_promotion_asset(
+    customer_id: str,
+    promotion_target: str,
+    final_url: str = "https://example.com",
+    discount_modifier: str = "NONE",
+    percent_off: Optional[int] = None,
+    money_amount_off_micros: Optional[int] = None,
+    money_amount_off_currency: Optional[str] = None,
+    occasion: str = "NONE",
+    language_code: str = "en",
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    redemption_start_date: Optional[str] = None,
+    redemption_end_date: Optional[str] = None,
+    promotion_code: Optional[str] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a promotion asset that can be linked to campaigns or ad groups.
+
+    Promotion assets highlight sales and special offers in your ads.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        promotion_target: What the promotion is for (e.g., "Summer Collection", "All Shoes").
+        discount_modifier: One of: NONE, UP_TO. Default: NONE.
+        percent_off: Percentage discount (e.g., 20 for 20% off). Use this OR money_amount_off.
+        money_amount_off_micros: Money discount in micros (e.g., 5000000 = $5 off). Use this OR percent_off.
+        money_amount_off_currency: Currency code for money discount (e.g., "USD").
+        occasion: Occasion for the promotion. One of: NONE, NEW_YEARS, VALENTINES_DAY,
+            EASTER, MOTHERS_DAY, FATHERS_DAY, LABOR_DAY, BACK_TO_SCHOOL, HALLOWEEN,
+            BLACK_FRIDAY, CYBER_MONDAY, CHRISTMAS, BOXING_DAY, and more. Default: NONE.
+        language_code: Language code (e.g., "en"). Default: "en".
+        start_date: Asset start date in YYYY-MM-DD format. Optional.
+        end_date: Asset end date in YYYY-MM-DD format. Optional.
+        redemption_start_date: Promotion redemption start date in YYYY-MM-DD format. Optional.
+        redemption_end_date: Promotion redemption end date in YYYY-MM-DD format. Optional.
+        promotion_code: A promotion code users can use (e.g., "SAVE20"). Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    asset.final_urls.append(final_url)
+    asset.promotion_asset.promotion_target = promotion_target
+    asset.promotion_asset.language_code = language_code
+
+    # Set discount
+    if discount_modifier and discount_modifier != "NONE":
+        discount_enum = client.enums.PromotionExtensionDiscountModifierEnum
+        asset.promotion_asset.discount_modifier = getattr(
+            discount_enum, discount_modifier
+        )
+
+    if percent_off is not None:
+        # Proto-plus auto-multiplies by 100, so for 20% we need
+        # 200_000 (which becomes 20_000_000 micros internally)
+        asset.promotion_asset.percent_off = int(percent_off) * 10_000
+    elif money_amount_off_micros is not None:
+        asset.promotion_asset.money_amount_off.amount_micros = (
+            money_amount_off_micros
+        )
+        if money_amount_off_currency:
+            asset.promotion_asset.money_amount_off.currency_code = (
+                money_amount_off_currency
+            )
+
+    # Set occasion
+    if occasion and occasion != "NONE":
+        occasion_enum = client.enums.PromotionExtensionOccasionEnum
+        asset.promotion_asset.occasion = getattr(occasion_enum, occasion)
+
+    # Set dates
+    if start_date:
+        asset.promotion_asset.start_date = start_date
+    if end_date:
+        asset.promotion_asset.end_date = end_date
+    if redemption_start_date:
+        asset.promotion_asset.redemption_start_date = redemption_start_date
+    if redemption_end_date:
+        asset.promotion_asset.redemption_end_date = redemption_end_date
+
+    # Set promotion code
+    if promotion_code:
+        asset.promotion_asset.promotion_code = promotion_code
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Promotion asset for '{promotion_target}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_price_asset(
+    customer_id: str,
+    price_type: str,
+    price_offerings: List[Dict[str, str]],
+    language_code: str = "en",
+    price_qualifier: str = "NONE",
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a price asset that can be linked to campaigns or ad groups.
+
+    Price assets showcase your products or services with their prices.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        price_type: The type of price. One of: BRANDS, EVENTS, LOCATIONS, NEIGHBORHOODS,
+            PRODUCT_CATEGORIES, PRODUCT_TIERS, SERVICES, SERVICE_CATEGORIES, SERVICE_TIERS.
+        price_offerings: List of price offerings (min 3, max 8), each with:
+            - header: The offering name (max 25 characters).
+            - description: Description of the offering (max 25 characters).
+            - price_micros: Price in micros (e.g., 9990000 = $9.99).
+            - currency_code: Currency code (e.g., "USD").
+            - unit: Price unit. One of: PER_HOUR, PER_DAY, PER_WEEK, PER_MONTH, PER_YEAR, NONE.
+            - final_url: The landing page URL for this offering.
+        language_code: Language code (e.g., "en"). Default: "en".
+        price_qualifier: One of: NONE, FROM, UP_TO, AVERAGE. Default: "NONE".
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+
+    # Set price type
+    type_enum = client.enums.PriceExtensionTypeEnum
+    asset.price_asset.type_ = getattr(type_enum, price_type)
+    asset.price_asset.language_code = language_code
+
+    # Set price qualifier
+    qualifier_enum = client.enums.PriceExtensionPriceQualifierEnum
+    asset.price_asset.price_qualifier = getattr(qualifier_enum, price_qualifier)
+
+    # Add offerings
+    for offering in price_offerings:
+        price_offering = client.get_type("PriceOffering")
+        price_offering.header = offering["header"]
+        price_offering.description = offering["description"]
+        price_offering.price.amount_micros = int(offering["price_micros"])
+        price_offering.price.currency_code = offering.get(
+            "currency_code", "USD"
+        )
+        price_offering.final_url = offering["final_url"]
+
+        unit = offering.get("unit", "NONE")
+        unit_enum = client.enums.PriceExtensionPriceUnitEnum
+        price_offering.unit = getattr(unit_enum, unit)
+
+        asset.price_asset.price_offerings.append(price_offering)
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Price asset with {len(price_offerings)} offerings created successfully.",
+    }
+
+
+@mcp.tool()
+def create_lead_form_asset(
+    customer_id: str,
+    business_name: str,
+    headline: str,
+    description: str,
+    call_to_action_type: str,
+    privacy_policy_url: str,
+    fields: List[str],
+    post_submit_headline: Optional[str] = None,
+    post_submit_description: Optional[str] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a lead form asset that can be linked to campaigns or ad groups.
+
+    Lead form assets collect user information directly from the ad.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        business_name: Your business name.
+        headline: The lead form headline (max 30 characters).
+        description: The lead form description (max 200 characters).
+        call_to_action_type: One of: LEARN_MORE, GET_QUOTE, APPLY_NOW, SIGN_UP,
+            CONTACT_US, SUBSCRIBE, DOWNLOAD, BOOK_NOW, GET_OFFER, REGISTER, GET_INFO,
+            REQUEST_DEMO, JOIN_NOW, GET_STARTED.
+        privacy_policy_url: URL to your privacy policy.
+        fields: List of form fields to collect. Options: FULL_NAME, EMAIL, PHONE_NUMBER,
+            POSTAL_CODE, CITY, REGION, COUNTRY, WORK_EMAIL, COMPANY_NAME, WORK_PHONE,
+            JOB_TITLE, FIRST_NAME, LAST_NAME.
+        post_submit_headline: Headline shown after form submission. Optional.
+        post_submit_description: Description shown after form submission. Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    lead_form = asset.lead_form_asset
+    lead_form.business_name = business_name
+    lead_form.headline = headline
+    lead_form.description = description
+    lead_form.privacy_policy_url = privacy_policy_url
+    lead_form.call_to_action_description = description
+    asset.final_urls.append(privacy_policy_url)
+
+    # Set call to action
+    cta_enum = client.enums.LeadFormCallToActionTypeEnum
+    lead_form.call_to_action_type = getattr(cta_enum, call_to_action_type)
+
+    # Add form fields
+    for field_name in fields:
+        field = client.get_type("LeadFormField")
+        field_type_enum = client.enums.LeadFormFieldUserInputTypeEnum
+        field.input_type = getattr(field_type_enum, field_name)
+        lead_form.fields.append(field)
+
+    # Post-submit content
+    if post_submit_headline:
+        lead_form.post_submit_headline = post_submit_headline
+    if post_submit_description:
+        lead_form.post_submit_description = post_submit_description
+
+    # Default post-submit CTA
+    post_cta_enum = client.enums.LeadFormPostSubmitCallToActionTypeEnum
+    lead_form.post_submit_call_to_action_type = post_cta_enum.VISIT_SITE
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Lead form asset '{headline}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_text_asset(
+    customer_id: str,
+    text: str,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a text asset for use in Performance Max asset groups.
+
+    Use this to create headline, description, and long headline assets
+    that can be linked to asset groups.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        text: The text content. Character limits depend on usage:
+            - Headlines: max 30 characters
+            - Long headlines: max 90 characters
+            - Descriptions: max 90 characters
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    asset.text_asset.text = text
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"Text asset '{text}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_youtube_video_asset(
+    customer_id: str,
+    youtube_video_id: str,
+    asset_name: Optional[str] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a YouTube video asset for use in Performance Max campaigns.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        youtube_video_id: The YouTube video ID (e.g., "dQw4w9WgXcQ" from the URL).
+        asset_name: Optional name for the asset. If not provided, uses the video ID.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the created asset resource name.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    asset_service = client.get_service("AssetService")
+
+    asset_operation = client.get_type("AssetOperation")
+    asset = asset_operation.create
+    asset.name = asset_name or f"YouTube Video {youtube_video_id}"
+    asset.youtube_video_asset.youtube_video_id = youtube_video_id
+
+    response = asset_service.mutate_assets(
+        customer_id=customer_id, operations=[asset_operation]
+    )
+
+    return {
+        "asset_resource_name": response.results[0].resource_name,
+        "message": f"YouTube video asset '{youtube_video_id}' created successfully.",
+    }

--- a/ads_mcp/tools/campaigns.py
+++ b/ads_mcp/tools/campaigns.py
@@ -1,0 +1,433 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for creating, editing, and managing campaigns via the MCP server."""
+
+from typing import Dict, Any, Optional
+from ads_mcp.coordinator import mcp
+import ads_mcp.utils as utils
+
+
+@mcp.tool()
+def create_campaign(
+    customer_id: str,
+    name: str,
+    budget_amount_micros: int,
+    advertising_channel_type: str = "SEARCH",
+    status: str = "PAUSED",
+    bidding_strategy_type: str = "MANUAL_CPC",
+    target_cpa_micros: Optional[int] = None,
+    target_roas: Optional[float] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a new Google Ads campaign with a budget.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        name: The name for the new campaign.
+        budget_amount_micros: Daily budget in micros (e.g., 10000000 = $10.00).
+        advertising_channel_type: Channel type. One of: SEARCH, DISPLAY, SHOPPING, VIDEO, MULTI_CHANNEL. Default: SEARCH.
+        status: Initial campaign status. One of: ENABLED, PAUSED. Default: PAUSED.
+        bidding_strategy_type: Bidding strategy. One of: MANUAL_CPC, MAXIMIZE_CONVERSIONS, MAXIMIZE_CONVERSION_VALUE, TARGET_CPA, TARGET_ROAS, TARGET_SPEND. Default: MANUAL_CPC.
+        target_cpa_micros: Target CPA in micros, required when bidding_strategy_type is TARGET_CPA.
+        target_roas: Target ROAS (e.g., 2.0 for 200%), required when bidding_strategy_type is TARGET_ROAS.
+        start_date: Campaign start date in YYYY-MM-DD format. Optional.
+        end_date: Campaign end date in YYYY-MM-DD format. Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with created campaign and budget resource names.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+
+    # Step 1: Create the campaign budget
+    campaign_budget_service = client.get_service("CampaignBudgetService")
+    campaign_budget_operation = client.get_type("CampaignBudgetOperation")
+    campaign_budget = campaign_budget_operation.create
+    campaign_budget.name = f"Budget for {name}"
+    campaign_budget.amount_micros = budget_amount_micros
+    campaign_budget.delivery_method = (
+        client.enums.BudgetDeliveryMethodEnum.STANDARD
+    )
+
+    budget_response = campaign_budget_service.mutate_campaign_budgets(
+        customer_id=customer_id, operations=[campaign_budget_operation]
+    )
+    budget_resource_name = budget_response.results[0].resource_name
+
+    # Step 2: Create the campaign
+    campaign_service = client.get_service("CampaignService")
+    campaign_operation = client.get_type("CampaignOperation")
+    campaign = campaign_operation.create
+    campaign.name = name
+    campaign.campaign_budget = budget_resource_name
+
+    # Set advertising channel type
+    channel_type_enum = client.enums.AdvertisingChannelTypeEnum
+    campaign.advertising_channel_type = getattr(
+        channel_type_enum, advertising_channel_type
+    )
+
+    # Set status
+    status_enum = client.enums.CampaignStatusEnum
+    campaign.status = getattr(status_enum, status)
+
+    # Set bidding strategy using client.copy_from for empty message fields
+    if bidding_strategy_type == "MANUAL_CPC":
+        client.copy_from(campaign.manual_cpc, client.get_type("ManualCpc"))
+    elif bidding_strategy_type == "MAXIMIZE_CONVERSIONS":
+        client.copy_from(
+            campaign.maximize_conversions,
+            client.get_type("MaximizeConversions"),
+        )
+    elif bidding_strategy_type == "MAXIMIZE_CONVERSION_VALUE":
+        client.copy_from(
+            campaign.maximize_conversion_value,
+            client.get_type("MaximizeConversionValue"),
+        )
+    elif bidding_strategy_type == "TARGET_CPA":
+        if target_cpa_micros is None:
+            raise ValueError(
+                "target_cpa_micros is required for TARGET_CPA bidding."
+            )
+        campaign.maximize_conversions.target_cpa_micros = target_cpa_micros
+    elif bidding_strategy_type == "TARGET_ROAS":
+        if target_roas is None:
+            raise ValueError("target_roas is required for TARGET_ROAS bidding.")
+        campaign.maximize_conversion_value.target_roas = target_roas
+    elif bidding_strategy_type == "TARGET_SPEND":
+        client.copy_from(campaign.target_spend, client.get_type("TargetSpend"))
+
+    # Set network settings for Search campaigns
+    if advertising_channel_type == "SEARCH":
+        campaign.network_settings.target_google_search = True
+        campaign.network_settings.target_search_network = True
+
+    # Set EU political advertising compliance field (required since API v19.2)
+    # This is an enum, not a bool.
+    campaign.contains_eu_political_advertising = (
+        client.enums.EuPoliticalAdvertisingStatusEnum.DOES_NOT_CONTAIN_EU_POLITICAL_ADVERTISING
+    )
+
+    # Set dates if provided
+    if start_date:
+        campaign.start_date = start_date
+    if end_date:
+        campaign.end_date = end_date
+
+    campaign_response = campaign_service.mutate_campaigns(
+        customer_id=customer_id, operations=[campaign_operation]
+    )
+    campaign_resource_name = campaign_response.results[0].resource_name
+
+    return {
+        "campaign_resource_name": campaign_resource_name,
+        "budget_resource_name": budget_resource_name,
+        "message": f"Campaign '{name}' created successfully.",
+    }
+
+
+@mcp.tool()
+def create_performance_max_campaign(
+    customer_id: str,
+    name: str,
+    budget_amount_micros: int,
+    business_name_asset_resource_name: str,
+    logo_asset_resource_name: str,
+    status: str = "PAUSED",
+    bidding_strategy_type: str = "MAXIMIZE_CONVERSIONS",
+    target_cpa_micros: Optional[int] = None,
+    target_roas: Optional[float] = None,
+    final_url_expansion_opt_out: bool = False,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a Performance Max campaign with a budget, business name, and logo.
+
+    PMax campaigns require a business name and logo asset linked at the campaign
+    level (Brand Guidelines). Create these assets first using create_text_asset
+    (for business name) and create_image_asset (for logo), then pass their
+    resource names here.
+
+    After creating the campaign, create more assets and an asset group using
+    create_text_asset, create_image_asset, create_youtube_video_asset,
+    and then create_asset_group.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        name: The name for the new campaign.
+        budget_amount_micros: Daily budget in micros (e.g., 10000000 = $10.00).
+        business_name_asset_resource_name: Resource name of a text asset for the business name.
+        logo_asset_resource_name: Resource name of an image asset for the logo (square, 1200x1200).
+        status: Initial campaign status. One of: ENABLED, PAUSED. Default: PAUSED.
+        bidding_strategy_type: One of: MAXIMIZE_CONVERSIONS, MAXIMIZE_CONVERSION_VALUE.
+            Default: MAXIMIZE_CONVERSIONS.
+        target_cpa_micros: Target CPA in micros, optional with MAXIMIZE_CONVERSIONS.
+        target_roas: Target ROAS (e.g., 2.0 for 200%), optional with MAXIMIZE_CONVERSION_VALUE.
+        final_url_expansion_opt_out: Set True to opt out of final URL expansion. Default: False.
+        start_date: Campaign start date in YYYY-MM-DD format. Optional.
+        end_date: Campaign end date in YYYY-MM-DD format. Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with created campaign and budget resource names.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    ga_service = client.get_service("GoogleAdsService")
+
+    operations = []
+
+    # Operation 1: Create the campaign budget
+    budget_op = client.get_type("MutateOperation")
+    campaign_budget = budget_op.campaign_budget_operation.create
+    campaign_budget.name = f"PMax Budget for {name}"
+    campaign_budget.amount_micros = budget_amount_micros
+    campaign_budget.delivery_method = (
+        client.enums.BudgetDeliveryMethodEnum.STANDARD
+    )
+    campaign_budget.explicitly_shared = False
+    # Use temporary resource name for referencing in same batch
+    budget_temp_rn = f"customers/{customer_id}/campaignBudgets/-1"
+    campaign_budget.resource_name = budget_temp_rn
+    operations.append(budget_op)
+
+    # Operation 2: Create the Performance Max campaign
+    campaign_op = client.get_type("MutateOperation")
+    campaign = campaign_op.campaign_operation.create
+    campaign.name = name
+    campaign.campaign_budget = budget_temp_rn
+
+    # Performance Max specific settings
+    campaign.advertising_channel_type = (
+        client.enums.AdvertisingChannelTypeEnum.PERFORMANCE_MAX
+    )
+
+    # Set status
+    status_enum = client.enums.CampaignStatusEnum
+    campaign.status = getattr(status_enum, status)
+
+    # Set bidding strategy
+    if bidding_strategy_type == "MAXIMIZE_CONVERSIONS":
+        if target_cpa_micros:
+            campaign.maximize_conversions.target_cpa_micros = target_cpa_micros
+        else:
+            client.copy_from(
+                campaign.maximize_conversions,
+                client.get_type("MaximizeConversions"),
+            )
+    elif bidding_strategy_type == "MAXIMIZE_CONVERSION_VALUE":
+        if target_roas:
+            campaign.maximize_conversion_value.target_roas = target_roas
+        else:
+            client.copy_from(
+                campaign.maximize_conversion_value,
+                client.get_type("MaximizeConversionValue"),
+            )
+
+    # URL expansion
+    if final_url_expansion_opt_out:
+        campaign.url_expansion_opt_out = True
+
+    # EU political advertising compliance
+    campaign.contains_eu_political_advertising = (
+        client.enums.EuPoliticalAdvertisingStatusEnum.DOES_NOT_CONTAIN_EU_POLITICAL_ADVERTISING
+    )
+
+    # Set dates if provided
+    if start_date:
+        campaign.start_date = start_date
+    if end_date:
+        campaign.end_date = end_date
+
+    # Use temporary resource name for referencing in same batch
+    campaign_temp_rn = f"customers/{customer_id}/campaigns/-2"
+    campaign.resource_name = campaign_temp_rn
+    operations.append(campaign_op)
+
+    # Operation 3: Link business name asset to campaign
+    biz_name_op = client.get_type("MutateOperation")
+    biz_name_asset = biz_name_op.campaign_asset_operation.create
+    biz_name_asset.campaign = campaign_temp_rn
+    biz_name_asset.asset = business_name_asset_resource_name
+    biz_name_asset.field_type = client.enums.AssetFieldTypeEnum.BUSINESS_NAME
+    operations.append(biz_name_op)
+
+    # Operation 4: Link logo asset to campaign
+    logo_op = client.get_type("MutateOperation")
+    logo_asset = logo_op.campaign_asset_operation.create
+    logo_asset.campaign = campaign_temp_rn
+    logo_asset.asset = logo_asset_resource_name
+    logo_asset.field_type = client.enums.AssetFieldTypeEnum.LOGO
+    operations.append(logo_op)
+
+    # Execute batch mutate
+    response = ga_service.mutate(
+        customer_id=customer_id, mutate_operations=operations
+    )
+
+    budget_rn = response.mutate_operation_responses[
+        0
+    ].campaign_budget_result.resource_name
+    campaign_rn = response.mutate_operation_responses[
+        1
+    ].campaign_result.resource_name
+
+    return {
+        "campaign_resource_name": campaign_rn,
+        "budget_resource_name": budget_rn,
+        "message": f"Performance Max campaign '{name}' created with business name and logo.",
+    }
+
+
+@mcp.tool()
+def update_campaign(
+    customer_id: str,
+    campaign_id: str,
+    name: Optional[str] = None,
+    status: Optional[str] = None,
+    budget_amount_micros: Optional[int] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Updates an existing Google Ads campaign's settings.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        campaign_id: The ID of the campaign to update.
+        name: New campaign name. Optional.
+        status: New status. One of: ENABLED, PAUSED, REMOVED. Optional.
+        budget_amount_micros: New daily budget in micros (e.g., 10000000 = $10.00). Optional.
+        start_date: New start date in YYYY-MM-DD format. Optional.
+        end_date: New end date in YYYY-MM-DD format. Optional.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the updated resource names and a confirmation message.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    results = {}
+
+    # Update campaign budget if specified
+    if budget_amount_micros is not None:
+        # First, get the current campaign's budget resource name
+        ga_service = client.get_service("GoogleAdsService")
+        query = (
+            f"SELECT campaign.campaign_budget FROM campaign "
+            f"WHERE campaign.id = {campaign_id}"
+        )
+        response = ga_service.search(customer_id=customer_id, query=query)
+        budget_resource_name = None
+        for row in response:
+            budget_resource_name = row.campaign.campaign_budget
+            break
+
+        if budget_resource_name:
+            budget_service = client.get_service("CampaignBudgetService")
+            budget_operation = client.get_type("CampaignBudgetOperation")
+            budget = budget_operation.update
+            budget.resource_name = budget_resource_name
+            budget.amount_micros = budget_amount_micros
+            client.copy_from(
+                budget_operation.update_mask,
+                utils.create_field_mask(budget),
+            )
+            budget_response = budget_service.mutate_campaign_budgets(
+                customer_id=customer_id, operations=[budget_operation]
+            )
+            results["budget_resource_name"] = budget_response.results[
+                0
+            ].resource_name
+
+    # Update campaign fields if any are specified
+    if any([name, status, start_date, end_date]):
+        campaign_service = client.get_service("CampaignService")
+        campaign_operation = client.get_type("CampaignOperation")
+        campaign = campaign_operation.update
+        campaign.resource_name = campaign_service.campaign_path(
+            customer_id, campaign_id
+        )
+
+        if name is not None:
+            campaign.name = name
+        if status is not None:
+            status_enum = client.enums.CampaignStatusEnum
+            campaign.status = getattr(status_enum, status)
+        if start_date is not None:
+            campaign.start_date = start_date
+        if end_date is not None:
+            campaign.end_date = end_date
+
+        client.copy_from(
+            campaign_operation.update_mask,
+            utils.create_field_mask(campaign),
+        )
+        campaign_response = campaign_service.mutate_campaigns(
+            customer_id=customer_id, operations=[campaign_operation]
+        )
+        results["campaign_resource_name"] = campaign_response.results[
+            0
+        ].resource_name
+
+    results["message"] = f"Campaign {campaign_id} updated successfully."
+    return results
+
+
+@mcp.tool()
+def set_campaign_status(
+    customer_id: str,
+    campaign_id: str,
+    status: str,
+    login_customer_id: Optional[str] = None,
+) -> Dict[str, str]:
+    """Enables, pauses, or removes a Google Ads campaign.
+
+    This is a convenience tool for quickly changing campaign status.
+
+    Args:
+        customer_id: The Google Ads customer ID (numbers only, no hyphens).
+        campaign_id: The ID of the campaign.
+        status: The new status. One of: ENABLED, PAUSED, REMOVED.
+        login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.
+
+    Returns:
+        Dictionary with the updated resource name and confirmation message.
+    """
+    client = utils.get_googleads_client(login_customer_id=login_customer_id)
+    campaign_service = client.get_service("CampaignService")
+    campaign_operation = client.get_type("CampaignOperation")
+    campaign = campaign_operation.update
+    campaign.resource_name = campaign_service.campaign_path(
+        customer_id, campaign_id
+    )
+
+    status_enum = client.enums.CampaignStatusEnum
+    campaign.status = getattr(status_enum, status)
+
+    client.copy_from(
+        campaign_operation.update_mask,
+        utils.create_field_mask(campaign),
+    )
+
+    response = campaign_service.mutate_campaigns(
+        customer_id=customer_id, operations=[campaign_operation]
+    )
+
+    return {
+        "campaign_resource_name": response.results[0].resource_name,
+        "message": f"Campaign {campaign_id} status set to {status}.",
+    }

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -61,15 +61,17 @@ def _get_login_customer_id() -> str | None:
     return os.environ.get("GOOGLE_ADS_LOGIN_CUSTOMER_ID")
 
 
-def _get_googleads_client() -> GoogleAdsClient:
+def _get_googleads_client(
+    login_customer_id: str = None,
+) -> GoogleAdsClient:
     args = {
         "credentials": _create_credentials(),
         "developer_token": _get_developer_token(),
         "use_proto_plus": True,
     }
 
-    # If the login-customer-id is not set, avoid setting None.
-    login_customer_id = _get_login_customer_id()
+    if not login_customer_id:
+        login_customer_id = _get_login_customer_id()
 
     if login_customer_id:
         args["login_customer_id"] = login_customer_id
@@ -79,18 +81,59 @@ def _get_googleads_client() -> GoogleAdsClient:
     return client
 
 
-def get_googleads_service(serviceName: str) -> GoogleAdsServiceClient:
-    return _get_googleads_client().get_service(
+# Lazy default client - initialized on first use to avoid
+# crashing at import time when credentials are not available
+_default_client = None
+
+
+def _get_default_client():
+    global _default_client
+    if _default_client is None:
+        _default_client = _get_googleads_client()
+    return _default_client
+
+
+def get_googleads_service(
+    serviceName: str, login_customer_id: str = None
+) -> GoogleAdsServiceClient:
+    """Gets a Google Ads service client.
+
+    Args:
+        serviceName: The service name (e.g., "GoogleAdsService").
+        login_customer_id: Optional manager account ID to use
+            instead of the env var.
+    """
+    if login_customer_id:
+        client = _get_googleads_client(login_customer_id)
+    else:
+        client = _get_default_client()
+
+    return client.get_service(
         serviceName, interceptors=[MCPHeaderInterceptor()]
     )
 
 
 def get_googleads_type(typeName: str):
-    return _get_googleads_client().get_type(typeName)
+    return _get_default_client().get_type(typeName)
 
 
-def get_googleads_client():
-    return _get_googleads_client()
+def get_googleads_client(login_customer_id: str = None):
+    if login_customer_id:
+        return _get_googleads_client(login_customer_id)
+    return _get_default_client()
+
+
+def create_field_mask(pb_object):
+    """Creates a field mask from a protobuf object.
+
+    Uses protobuf_helpers to compare the object against
+    an empty instance to detect which fields have been set.
+    """
+    from google.api_core.protobuf_helpers import field_mask
+
+    if hasattr(pb_object, "_pb"):
+        return field_mask(None, pb_object._pb)
+    return field_mask(None, pb_object)
 
 
 def format_output_value(value: Any) -> Any:

--- a/tests/smoke/golden_tools_list.json
+++ b/tests/smoke/golden_tools_list.json
@@ -2073,6 +2073,63 @@
       }
     },
     {
+      "name": "set_ad_schedule",
+      "description": "Sets ad schedule (day/hour targeting) for a campaign.\n\nControls which days and hours ads are shown.\n\nArgs:\n    customer_id: The Google Ads customer ID.\n    campaign_id: The ID of the campaign.\n    schedules: List of schedule objects, each with:\n        - day_of_week: One of MONDAY, TUESDAY, WEDNESDAY,\n            THURSDAY, FRIDAY, SATURDAY, SUNDAY.\n        - start_hour: Start hour (0-23).\n        - start_minute: One of ZERO, FIFTEEN, THIRTY,\n            FORTY_FIVE. Default: ZERO.\n        - end_hour: End hour (0-23). Use 24 for midnight.\n        - end_minute: One of ZERO, FIFTEEN, THIRTY,\n            FORTY_FIVE. Default: ZERO.\n    login_customer_id: Optional manager account ID.\n\nReturns:\n    Dictionary with created schedule criteria.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "schedules": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Schedules",
+            "type": "array"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id",
+          "schedules"
+        ],
+        "title": "set_ad_scheduleArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "set_ad_scheduleOutput",
+        "type": "object"
+      }
+    },
+    {
       "name": "set_campaign_status",
       "description": "Enables, pauses, or removes a Google Ads campaign.\n\nThis is a convenience tool for quickly changing campaign status.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    campaign_id: The ID of the campaign.\n    status: The new status. One of: ENABLED, PAUSED, REMOVED.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the updated resource name and confirmation message.\n",
       "inputSchema": {
@@ -2124,6 +2181,62 @@
           "result"
         ],
         "title": "set_campaign_statusOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "set_geo_targets",
+      "description": "Sets geo targeting for a campaign by adding location criteria.\n\nCommon location IDs (Google Ads geo target constants):\n    US=2840, UK=2826, Canada=2124, Australia=2036,\n    India=2356, Singapore=2702, UAE=2784,\n    Germany=2276, France=2250\n\nFind more IDs at:\nhttps://developers.google.com/google-ads/api/data/geotargets\n\nArgs:\n    customer_id: The Google Ads customer ID.\n    campaign_id: The ID of the campaign.\n    location_ids: List of geo target constant IDs.\n    login_customer_id: Optional manager account ID.\n\nReturns:\n    Dictionary with created location criteria.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "location_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Location Ids",
+            "type": "array"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id",
+          "location_ids"
+        ],
+        "title": "set_geo_targetsArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "set_geo_targetsOutput",
         "type": "object"
       }
     },

--- a/tests/smoke/golden_tools_list.json
+++ b/tests/smoke/golden_tools_list.json
@@ -1,9 +1,1542 @@
 {
   "tools": [
     {
-      "annotations": {
-        "readOnlyHint": true
+      "name": "add_assets_to_asset_group",
+      "description": "Adds assets to an existing asset group.\n\nUse this to add more assets to an asset group after it's been created.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    asset_group_resource_name: The resource name of the asset group.\n    assets: List of asset objects, each with:\n        - asset_resource_name: The resource name of the asset.\n        - field_type: One of: HEADLINE, DESCRIPTION, LONG_HEADLINE,\n            MARKETING_IMAGE, SQUARE_MARKETING_IMAGE, LOGO,\n            LANDSCAPE_LOGO, YOUTUBE_VIDEO, CALL_TO_ACTION_SELECTION.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the count of assets added.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "asset_group_resource_name": {
+            "title": "Asset Group Resource Name",
+            "type": "string"
+          },
+          "assets": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Assets",
+            "type": "array"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "asset_group_resource_name",
+          "assets"
+        ],
+        "title": "add_assets_to_asset_groupArguments",
+        "type": "object"
       },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "add_assets_to_asset_groupOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "add_keywords",
+      "description": "Adds keywords to an ad group.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    ad_group_id: The ID of the ad group to add keywords to.\n    keywords: List of keyword objects, each with:\n        - text: The keyword text (e.g., \"buy shoes online\").\n        - match_type: One of: EXACT, PHRASE, BROAD. Default: BROAD.\n        - cpc_bid_micros: Optional CPC bid in micros for this keyword.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with created keyword resource names and count.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "ad_group_id": {
+            "title": "Ad Group Id",
+            "type": "string"
+          },
+          "keywords": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Keywords",
+            "type": "array"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "ad_group_id",
+          "keywords"
+        ],
+        "title": "add_keywordsArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "add_keywordsOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "add_negative_keywords",
+      "description": "Adds negative keywords to a campaign to block irrelevant traffic.\n\nNegative keywords prevent your ads from showing for specific search terms.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    campaign_id: The ID of the campaign to add negative keywords to.\n    keywords: List of keyword objects, each with:\n        - text: The keyword text (e.g., \"free LMS\").\n        - match_type: One of: EXACT, PHRASE, BROAD. Default: BROAD.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with created negative keyword resource names.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "keywords": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Keywords",
+            "type": "array"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id",
+          "keywords"
+        ],
+        "title": "add_negative_keywordsArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "add_negative_keywordsOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_ad_group",
+      "description": "Creates a new ad group within a campaign.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    campaign_id: The ID of the campaign to add the ad group to.\n    name: The name for the new ad group.\n    cpc_bid_micros: Default max CPC bid in micros (e.g., 1000000 = $1.00). Default: 1000000.\n    ad_group_type: Ad group type. One of: SEARCH_STANDARD, DISPLAY_STANDARD, SHOPPING_PRODUCT_ADS, VIDEO_BUMPER, VIDEO_TRUE_VIEW_IN_STREAM. Default: SEARCH_STANDARD.\n    status: Initial status. One of: ENABLED, PAUSED. Default: ENABLED.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created ad group resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "cpc_bid_micros": {
+            "default": 1000000,
+            "title": "Cpc Bid Micros",
+            "type": "integer"
+          },
+          "ad_group_type": {
+            "default": "SEARCH_STANDARD",
+            "title": "Ad Group Type",
+            "type": "string"
+          },
+          "status": {
+            "default": "ENABLED",
+            "title": "Status",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id",
+          "name"
+        ],
+        "title": "create_ad_groupArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_ad_groupOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_asset_group",
+      "description": "Creates an asset group for a Performance Max campaign and links all provided assets to it.\n\nAsset groups and their assets must be created together in a single batch request.\nCreate all required assets first using create_text_asset, create_image_asset, etc.,\nthen pass their resource names here.\n\nMinimum asset requirements for Performance Max:\n- At least 3 headlines (max 15)\n- At least 2 descriptions (max 5)\n- At least 1 long headline (max 5)\n- At least 1 marketing image (landscape, 1200x628 recommended)\n- At least 1 square marketing image (1200x1200 recommended)\n- At least 1 logo (1200x1200 recommended)\n- YouTube videos are optional but recommended\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    campaign_id: The ID of the Performance Max campaign.\n    name: Name for the asset group.\n    final_url: The landing page URL for the asset group.\n    headline_asset_resource_names: List of text asset resource names for headlines (min 3).\n    description_asset_resource_names: List of text asset resource names for descriptions (min 2).\n    long_headline_asset_resource_names: List of text asset resource names for long headlines (min 1).\n    marketing_image_asset_resource_names: List of image asset resource names for landscape images (min 1).\n    square_marketing_image_asset_resource_names: List of image asset resource names for square images (min 1).\n    logo_asset_resource_names: List of image asset resource names for logos (min 1).\n    youtube_video_asset_resource_names: List of YouTube video asset resource names. Optional.\n    final_mobile_url: Mobile landing page URL. Optional.\n    path1: First URL path text (max 15 characters). Optional.\n    path2: Second URL path text (max 15 characters). Optional.\n    status: Asset group status. One of: ENABLED, PAUSED. Default: ENABLED.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset group resource name and linked asset count.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "final_url": {
+            "title": "Final Url",
+            "type": "string"
+          },
+          "headline_asset_resource_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Headline Asset Resource Names",
+            "type": "array"
+          },
+          "description_asset_resource_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Description Asset Resource Names",
+            "type": "array"
+          },
+          "long_headline_asset_resource_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Long Headline Asset Resource Names",
+            "type": "array"
+          },
+          "marketing_image_asset_resource_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Marketing Image Asset Resource Names",
+            "type": "array"
+          },
+          "square_marketing_image_asset_resource_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Square Marketing Image Asset Resource Names",
+            "type": "array"
+          },
+          "logo_asset_resource_names": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Logo Asset Resource Names"
+          },
+          "youtube_video_asset_resource_names": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Youtube Video Asset Resource Names"
+          },
+          "final_mobile_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Final Mobile Url"
+          },
+          "path1": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Path1"
+          },
+          "path2": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Path2"
+          },
+          "status": {
+            "default": "ENABLED",
+            "title": "Status",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id",
+          "name",
+          "final_url",
+          "headline_asset_resource_names",
+          "description_asset_resource_names",
+          "long_headline_asset_resource_names",
+          "marketing_image_asset_resource_names",
+          "square_marketing_image_asset_resource_names"
+        ],
+        "title": "create_asset_groupArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_asset_groupOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_call_asset",
+      "description": "Creates a call asset that can be linked to campaigns or ad groups.\n\nCall assets add a phone number to your ad, allowing users to call directly.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    country_code: Two-letter country code (e.g., \"US\", \"GB\", \"IN\").\n    phone_number: The phone number string.\n    call_conversion_reporting_state: One of: DISABLED, USE_ACCOUNT_LEVEL_CALL_CONVERSION_ACTION,\n        USE_RESOURCE_LEVEL_CALL_CONVERSION_ACTION. Default: DISABLED.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "country_code": {
+            "title": "Country Code",
+            "type": "string"
+          },
+          "phone_number": {
+            "title": "Phone Number",
+            "type": "string"
+          },
+          "call_conversion_reporting_state": {
+            "default": "DISABLED",
+            "title": "Call Conversion Reporting State",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "country_code",
+          "phone_number"
+        ],
+        "title": "create_call_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_call_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_callout_asset",
+      "description": "Creates a callout asset that can be linked to campaigns or ad groups.\n\nCallouts add short snippets of text to your ad (e.g., \"Free Shipping\", \"24/7 Support\").\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    callout_text: The callout text (max 25 characters).\n    start_date: Start date in YYYY-MM-DD format. Optional.\n    end_date: End date in YYYY-MM-DD format. Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "callout_text": {
+            "title": "Callout Text",
+            "type": "string"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "End Date"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "callout_text"
+        ],
+        "title": "create_callout_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_callout_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_campaign",
+      "description": "Creates a new Google Ads campaign with a budget.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    name: The name for the new campaign.\n    budget_amount_micros: Daily budget in micros (e.g., 10000000 = $10.00).\n    advertising_channel_type: Channel type. One of: SEARCH, DISPLAY, SHOPPING, VIDEO, MULTI_CHANNEL. Default: SEARCH.\n    status: Initial campaign status. One of: ENABLED, PAUSED. Default: PAUSED.\n    bidding_strategy_type: Bidding strategy. One of: MANUAL_CPC, MAXIMIZE_CONVERSIONS, MAXIMIZE_CONVERSION_VALUE, TARGET_CPA, TARGET_ROAS, TARGET_SPEND. Default: MANUAL_CPC.\n    target_cpa_micros: Target CPA in micros, required when bidding_strategy_type is TARGET_CPA.\n    target_roas: Target ROAS (e.g., 2.0 for 200%), required when bidding_strategy_type is TARGET_ROAS.\n    start_date: Campaign start date in YYYY-MM-DD format. Optional.\n    end_date: Campaign end date in YYYY-MM-DD format. Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with created campaign and budget resource names.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "budget_amount_micros": {
+            "title": "Budget Amount Micros",
+            "type": "integer"
+          },
+          "advertising_channel_type": {
+            "default": "SEARCH",
+            "title": "Advertising Channel Type",
+            "type": "string"
+          },
+          "status": {
+            "default": "PAUSED",
+            "title": "Status",
+            "type": "string"
+          },
+          "bidding_strategy_type": {
+            "default": "MANUAL_CPC",
+            "title": "Bidding Strategy Type",
+            "type": "string"
+          },
+          "target_cpa_micros": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Target Cpa Micros"
+          },
+          "target_roas": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Target Roas"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "End Date"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "name",
+          "budget_amount_micros"
+        ],
+        "title": "create_campaignArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_campaignOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_image_asset",
+      "description": "Creates an image asset from a URL or local file path.\n\nSupports both web URLs and local file paths on the user's computer.\n\nRecommended image sizes for Performance Max:\n- Marketing image (landscape): 1200x628\n- Square marketing image: 1200x1200\n- Logo: 1200x1200\n- Landscape logo: 1200x300\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    image_source: Either a URL (https://...) or a local file path (/path/to/image.jpg).\n    asset_name: A name for the image asset.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "image_source": {
+            "title": "Image Source",
+            "type": "string"
+          },
+          "asset_name": {
+            "title": "Asset Name",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "image_source",
+          "asset_name"
+        ],
+        "title": "create_image_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_image_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_lead_form_asset",
+      "description": "Creates a lead form asset that can be linked to campaigns or ad groups.\n\nLead form assets collect user information directly from the ad.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    business_name: Your business name.\n    headline: The lead form headline (max 30 characters).\n    description: The lead form description (max 200 characters).\n    call_to_action_type: One of: LEARN_MORE, GET_QUOTE, APPLY_NOW, SIGN_UP,\n        CONTACT_US, SUBSCRIBE, DOWNLOAD, BOOK_NOW, GET_OFFER, REGISTER, GET_INFO,\n        REQUEST_DEMO, JOIN_NOW, GET_STARTED.\n    privacy_policy_url: URL to your privacy policy.\n    fields: List of form fields to collect. Options: FULL_NAME, EMAIL, PHONE_NUMBER,\n        POSTAL_CODE, CITY, REGION, COUNTRY, WORK_EMAIL, COMPANY_NAME, WORK_PHONE,\n        JOB_TITLE, FIRST_NAME, LAST_NAME.\n    post_submit_headline: Headline shown after form submission. Optional.\n    post_submit_description: Description shown after form submission. Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "business_name": {
+            "title": "Business Name",
+            "type": "string"
+          },
+          "headline": {
+            "title": "Headline",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "call_to_action_type": {
+            "title": "Call To Action Type",
+            "type": "string"
+          },
+          "privacy_policy_url": {
+            "title": "Privacy Policy Url",
+            "type": "string"
+          },
+          "fields": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Fields",
+            "type": "array"
+          },
+          "post_submit_headline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Post Submit Headline"
+          },
+          "post_submit_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Post Submit Description"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "business_name",
+          "headline",
+          "description",
+          "call_to_action_type",
+          "privacy_policy_url",
+          "fields"
+        ],
+        "title": "create_lead_form_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_lead_form_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_performance_max_campaign",
+      "description": "Creates a Performance Max campaign with a budget, business name, and logo.\n\nPMax campaigns require a business name and logo asset linked at the campaign\nlevel (Brand Guidelines). Create these assets first using create_text_asset\n(for business name) and create_image_asset (for logo), then pass their\nresource names here.\n\nAfter creating the campaign, create more assets and an asset group using\ncreate_text_asset, create_image_asset, create_youtube_video_asset,\nand then create_asset_group.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    name: The name for the new campaign.\n    budget_amount_micros: Daily budget in micros (e.g., 10000000 = $10.00).\n    business_name_asset_resource_name: Resource name of a text asset for the business name.\n    logo_asset_resource_name: Resource name of an image asset for the logo (square, 1200x1200).\n    status: Initial campaign status. One of: ENABLED, PAUSED. Default: PAUSED.\n    bidding_strategy_type: One of: MAXIMIZE_CONVERSIONS, MAXIMIZE_CONVERSION_VALUE.\n        Default: MAXIMIZE_CONVERSIONS.\n    target_cpa_micros: Target CPA in micros, optional with MAXIMIZE_CONVERSIONS.\n    target_roas: Target ROAS (e.g., 2.0 for 200%), optional with MAXIMIZE_CONVERSION_VALUE.\n    final_url_expansion_opt_out: Set True to opt out of final URL expansion. Default: False.\n    start_date: Campaign start date in YYYY-MM-DD format. Optional.\n    end_date: Campaign end date in YYYY-MM-DD format. Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with created campaign and budget resource names.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "budget_amount_micros": {
+            "title": "Budget Amount Micros",
+            "type": "integer"
+          },
+          "business_name_asset_resource_name": {
+            "title": "Business Name Asset Resource Name",
+            "type": "string"
+          },
+          "logo_asset_resource_name": {
+            "title": "Logo Asset Resource Name",
+            "type": "string"
+          },
+          "status": {
+            "default": "PAUSED",
+            "title": "Status",
+            "type": "string"
+          },
+          "bidding_strategy_type": {
+            "default": "MAXIMIZE_CONVERSIONS",
+            "title": "Bidding Strategy Type",
+            "type": "string"
+          },
+          "target_cpa_micros": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Target Cpa Micros"
+          },
+          "target_roas": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Target Roas"
+          },
+          "final_url_expansion_opt_out": {
+            "default": false,
+            "title": "Final Url Expansion Opt Out",
+            "type": "boolean"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "End Date"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "name",
+          "budget_amount_micros",
+          "business_name_asset_resource_name",
+          "logo_asset_resource_name"
+        ],
+        "title": "create_performance_max_campaignArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_performance_max_campaignOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_price_asset",
+      "description": "Creates a price asset that can be linked to campaigns or ad groups.\n\nPrice assets showcase your products or services with their prices.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    price_type: The type of price. One of: BRANDS, EVENTS, LOCATIONS, NEIGHBORHOODS,\n        PRODUCT_CATEGORIES, PRODUCT_TIERS, SERVICES, SERVICE_CATEGORIES, SERVICE_TIERS.\n    price_offerings: List of price offerings (min 3, max 8), each with:\n        - header: The offering name (max 25 characters).\n        - description: Description of the offering (max 25 characters).\n        - price_micros: Price in micros (e.g., 9990000 = $9.99).\n        - currency_code: Currency code (e.g., \"USD\").\n        - unit: Price unit. One of: PER_HOUR, PER_DAY, PER_WEEK, PER_MONTH, PER_YEAR, NONE.\n        - final_url: The landing page URL for this offering.\n    language_code: Language code (e.g., \"en\"). Default: \"en\".\n    price_qualifier: One of: NONE, FROM, UP_TO, AVERAGE. Default: \"NONE\".\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "price_type": {
+            "title": "Price Type",
+            "type": "string"
+          },
+          "price_offerings": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Price Offerings",
+            "type": "array"
+          },
+          "language_code": {
+            "default": "en",
+            "title": "Language Code",
+            "type": "string"
+          },
+          "price_qualifier": {
+            "default": "NONE",
+            "title": "Price Qualifier",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "price_type",
+          "price_offerings"
+        ],
+        "title": "create_price_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_price_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_promotion_asset",
+      "description": "Creates a promotion asset that can be linked to campaigns or ad groups.\n\nPromotion assets highlight sales and special offers in your ads.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    promotion_target: What the promotion is for (e.g., \"Summer Collection\", \"All Shoes\").\n    discount_modifier: One of: NONE, UP_TO. Default: NONE.\n    percent_off: Percentage discount (e.g., 20 for 20% off). Use this OR money_amount_off.\n    money_amount_off_micros: Money discount in micros (e.g., 5000000 = $5 off). Use this OR percent_off.\n    money_amount_off_currency: Currency code for money discount (e.g., \"USD\").\n    occasion: Occasion for the promotion. One of: NONE, NEW_YEARS, VALENTINES_DAY,\n        EASTER, MOTHERS_DAY, FATHERS_DAY, LABOR_DAY, BACK_TO_SCHOOL, HALLOWEEN,\n        BLACK_FRIDAY, CYBER_MONDAY, CHRISTMAS, BOXING_DAY, and more. Default: NONE.\n    language_code: Language code (e.g., \"en\"). Default: \"en\".\n    start_date: Asset start date in YYYY-MM-DD format. Optional.\n    end_date: Asset end date in YYYY-MM-DD format. Optional.\n    redemption_start_date: Promotion redemption start date in YYYY-MM-DD format. Optional.\n    redemption_end_date: Promotion redemption end date in YYYY-MM-DD format. Optional.\n    promotion_code: A promotion code users can use (e.g., \"SAVE20\"). Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "promotion_target": {
+            "title": "Promotion Target",
+            "type": "string"
+          },
+          "final_url": {
+            "default": "https://example.com",
+            "title": "Final Url",
+            "type": "string"
+          },
+          "discount_modifier": {
+            "default": "NONE",
+            "title": "Discount Modifier",
+            "type": "string"
+          },
+          "percent_off": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Percent Off"
+          },
+          "money_amount_off_micros": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Money Amount Off Micros"
+          },
+          "money_amount_off_currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Money Amount Off Currency"
+          },
+          "occasion": {
+            "default": "NONE",
+            "title": "Occasion",
+            "type": "string"
+          },
+          "language_code": {
+            "default": "en",
+            "title": "Language Code",
+            "type": "string"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "End Date"
+          },
+          "redemption_start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Redemption Start Date"
+          },
+          "redemption_end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Redemption End Date"
+          },
+          "promotion_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Promotion Code"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "promotion_target"
+        ],
+        "title": "create_promotion_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_promotion_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_responsive_search_ad",
+      "description": "Creates a responsive search ad in an ad group.\n\nResponsive search ads allow you to provide multiple headlines and descriptions,\nand Google Ads will automatically test different combinations.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    ad_group_id: The ID of the ad group to add the ad to.\n    headlines: List of headline texts (min 3, max 15). Each headline max 30 characters.\n    descriptions: List of description texts (min 2, max 4). Each description max 90 characters.\n    final_url: The landing page URL for the ad.\n    path1: First URL path text (max 15 characters). Optional.\n    path2: Second URL path text (max 15 characters). Optional.\n    status: Ad status. One of: ENABLED, PAUSED. Default: ENABLED.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created ad resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "ad_group_id": {
+            "title": "Ad Group Id",
+            "type": "string"
+          },
+          "headlines": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Headlines",
+            "type": "array"
+          },
+          "descriptions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Descriptions",
+            "type": "array"
+          },
+          "final_url": {
+            "title": "Final Url",
+            "type": "string"
+          },
+          "path1": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Path1"
+          },
+          "path2": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Path2"
+          },
+          "status": {
+            "default": "ENABLED",
+            "title": "Status",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "ad_group_id",
+          "headlines",
+          "descriptions",
+          "final_url"
+        ],
+        "title": "create_responsive_search_adArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_responsive_search_adOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_sitelink_asset",
+      "description": "Creates a sitelink asset that can be linked to campaigns or ad groups.\n\nSitelinks add additional links below your ad, directing users to specific pages.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    link_text: The text displayed for the sitelink (max 25 characters).\n    final_url: The URL the sitelink directs to.\n    description1: First line of description (max 35 characters). Optional.\n    description2: Second line of description (max 35 characters). Optional.\n    start_date: Start date in YYYY-MM-DD format. Optional.\n    end_date: End date in YYYY-MM-DD format. Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "link_text": {
+            "title": "Link Text",
+            "type": "string"
+          },
+          "final_url": {
+            "title": "Final Url",
+            "type": "string"
+          },
+          "description1": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Description1"
+          },
+          "description2": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Description2"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "End Date"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "link_text",
+          "final_url"
+        ],
+        "title": "create_sitelink_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_sitelink_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_structured_snippet_asset",
+      "description": "Creates a structured snippet asset that can be linked to campaigns or ad groups.\n\nStructured snippets highlight specific aspects of your products/services\n(e.g., header \"Brands\" with values [\"Nike\", \"Adidas\", \"Puma\"]).\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    header: The snippet header. One of: Amenities, Brands, Courses, Degree programs,\n        Destinations, Featured hotels, Insurance coverage, Models, Neighborhoods,\n        Service catalog, Shows, Styles, Types.\n    values: List of values for the snippet (min 3 values recommended).\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "header": {
+            "title": "Header",
+            "type": "string"
+          },
+          "values": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Values",
+            "type": "array"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "header",
+          "values"
+        ],
+        "title": "create_structured_snippet_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_structured_snippet_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_text_asset",
+      "description": "Creates a text asset for use in Performance Max asset groups.\n\nUse this to create headline, description, and long headline assets\nthat can be linked to asset groups.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    text: The text content. Character limits depend on usage:\n        - Headlines: max 30 characters\n        - Long headlines: max 90 characters\n        - Descriptions: max 90 characters\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "text"
+        ],
+        "title": "create_text_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_text_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_youtube_video_asset",
+      "description": "Creates a YouTube video asset for use in Performance Max campaigns.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    youtube_video_id: The YouTube video ID (e.g., \"dQw4w9WgXcQ\" from the URL).\n    asset_name: Optional name for the asset. If not provided, uses the video ID.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created asset resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "youtube_video_id": {
+            "title": "Youtube Video Id",
+            "type": "string"
+          },
+          "asset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Asset Name"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "youtube_video_id"
+        ],
+        "title": "create_youtube_video_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "create_youtube_video_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_resource_metadata",
       "description": "Retrieves the selectable, filterable, and sortable fields for a specific Google Ads resource.\n\nUse this tool to find out which fields you can select, filter by, or sort by\nwhen querying a specific resource (e.g., 'campaign', 'ad_group').\nDo not guess fields, you MUST use this tool to discover them.\n\nThe responses of this tool should be cached, as they don't change frequently.\n\nArgs:\n    resource_name: The name of the Google Ads resource (e.g., 'campaign', 'ad_group').\n",
       "inputSchema": {
         "properties": {
@@ -18,7 +1551,6 @@
         "title": "get_resource_metadataArguments",
         "type": "object"
       },
-      "name": "get_resource_metadata",
       "outputSchema": {
         "properties": {
           "result": {
@@ -32,16 +1564,191 @@
         ],
         "title": "get_resource_metadataOutput",
         "type": "object"
+      },
+      "annotations": {
+        "readOnlyHint": true
       }
     },
     {
+      "name": "link_asset_to_ad_group",
+      "description": "Links an existing asset to an ad group.\n\nAfter creating an asset (sitelink, callout, etc.), use this tool to\nattach it to an ad group so it appears with that ad group's ads.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    ad_group_id: The ID of the ad group to link the asset to.\n    asset_resource_name: The resource name of the asset (from create_*_asset tools).\n    field_type: The asset field type. One of: SITELINK, CALLOUT, STRUCTURED_SNIPPET,\n        CALL, PROMOTION, PRICE, LEAD_FORM, MOBILE_APP, HOTEL_CALLOUT, IMAGE.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created ad group asset link resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "ad_group_id": {
+            "title": "Ad Group Id",
+            "type": "string"
+          },
+          "asset_resource_name": {
+            "title": "Asset Resource Name",
+            "type": "string"
+          },
+          "field_type": {
+            "title": "Field Type",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "ad_group_id",
+          "asset_resource_name",
+          "field_type"
+        ],
+        "title": "link_asset_to_ad_groupArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "link_asset_to_ad_groupOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "link_asset_to_campaign",
+      "description": "Links an existing asset to a campaign.\n\nAfter creating an asset (sitelink, callout, etc.), use this tool to\nattach it to a campaign so it appears with that campaign's ads.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    campaign_id: The ID of the campaign to link the asset to.\n    asset_resource_name: The resource name of the asset (from create_*_asset tools).\n    field_type: The asset field type. One of: SITELINK, CALLOUT, STRUCTURED_SNIPPET,\n        CALL, PROMOTION, PRICE, LEAD_FORM, MOBILE_APP, HOTEL_CALLOUT, IMAGE,\n        BUSINESS_NAME, BUSINESS_LOGO.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created campaign asset link resource name.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "asset_resource_name": {
+            "title": "Asset Resource Name",
+            "type": "string"
+          },
+          "field_type": {
+            "title": "Field Type",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id",
+          "asset_resource_name",
+          "field_type"
+        ],
+        "title": "link_asset_to_campaignArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "link_asset_to_campaignOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "link_assets_to_customer",
+      "description": "Links assets at the customer (account) level so they apply to all campaigns.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    asset_resource_names: List of asset resource names to link.\n    field_type: The asset field type. One of: SITELINK, CALLOUT, STRUCTURED_SNIPPET,\n        CALL, PROMOTION, PRICE, LEAD_FORM, MOBILE_APP, BUSINESS_NAME, BUSINESS_LOGO.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the created customer asset link resource names.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "asset_resource_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Asset Resource Names",
+            "type": "array"
+          },
+          "field_type": {
+            "title": "Field Type",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "asset_resource_names",
+          "field_type"
+        ],
+        "title": "link_assets_to_customerArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "link_assets_to_customerOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_accessible_customers",
       "description": "Returns ids of customers directly accessible by the user authenticating the call.",
       "inputSchema": {
         "properties": {},
         "title": "list_accessible_customersArguments",
         "type": "object"
       },
-      "name": "list_accessible_customers",
       "outputSchema": {
         "properties": {
           "result": {
@@ -60,17 +1767,241 @@
       }
     },
     {
+      "name": "remove_ad",
+      "description": "Permanently removes an ad from an ad group.\n\nUse this to delete disapproved, old, or unwanted ads. This action\ncannot be undone \u2014 the ad will be permanently removed.\nRequires user confirmation via interactive elicitation before proceeding.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    ad_group_id: The ID of the ad group containing the ad.\n    ad_id: The ID of the ad to remove.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "ad_group_id": {
+            "title": "Ad Group Id",
+            "type": "string"
+          },
+          "ad_id": {
+            "title": "Ad Id",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "ad_group_id",
+          "ad_id"
+        ],
+        "title": "remove_adArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "remove_adOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "remove_asset_from_asset_group",
+      "description": "Removes an asset from an asset group.\n\nRequires user confirmation via interactive elicitation before proceeding.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    asset_group_resource_name: The resource name of the asset group.\n    asset_resource_name: The resource name of the asset to remove.\n    field_type: The field type of the asset. One of: HEADLINE, DESCRIPTION,\n        LONG_HEADLINE, MARKETING_IMAGE, SQUARE_MARKETING_IMAGE, LOGO,\n        LANDSCAPE_LOGO, YOUTUBE_VIDEO, CALL_TO_ACTION_SELECTION.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "asset_group_resource_name": {
+            "title": "Asset Group Resource Name",
+            "type": "string"
+          },
+          "asset_resource_name": {
+            "title": "Asset Resource Name",
+            "type": "string"
+          },
+          "field_type": {
+            "title": "Field Type",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "asset_group_resource_name",
+          "asset_resource_name",
+          "field_type"
+        ],
+        "title": "remove_asset_from_asset_groupArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "remove_asset_from_asset_groupOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "remove_campaign_asset",
+      "description": "Removes an asset link from a campaign.\n\nRequires user confirmation via interactive elicitation before proceeding.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    campaign_id: The ID of the campaign.\n    asset_id: The ID of the asset to unlink.\n    field_type: The asset field type (e.g., SITELINK, CALLOUT).\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "asset_id": {
+            "title": "Asset Id",
+            "type": "string"
+          },
+          "field_type": {
+            "title": "Field Type",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id",
+          "asset_id",
+          "field_type"
+        ],
+        "title": "remove_campaign_assetArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "remove_campaign_assetOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "remove_keyword",
+      "description": "Permanently removes a keyword from an ad group.\n\nThis action cannot be undone.\nRequires user confirmation via interactive elicitation before proceeding.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    ad_group_id: The ID of the ad group containing the keyword.\n    criterion_id: The criterion ID of the keyword to remove.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "ad_group_id": {
+            "title": "Ad Group Id",
+            "type": "string"
+          },
+          "criterion_id": {
+            "title": "Criterion Id",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "ad_group_id",
+          "criterion_id"
+        ],
+        "title": "remove_keywordArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "remove_keywordOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "search",
+      "title": "Fetches data from the Google Ads API using the search method",
       "description": "\nFetches data from the Google Ads API using the search method\n\nArgs:\n    customer_id: The id of the customer\n    fields: The fields to fetch\n    resource: The resource to return fields from\n    conditions: List of conditions to filter the data, combined using AND clauses\n    orderings: How the data is ordered\n    limit: The maximum number of rows to return\n\n\n\n### Hints\n    Language Grammar can be found at https://developers.google.com/google-ads/api/docs/query/grammar\n    All resources and descriptions are found at https://developers.google.com/google-ads/api/fields/v23/overview\n\n    For Conversion issues try looking in offline_conversion_upload_conversion_action_summary\n\n### Hint for customer_id\n    should be a string of numbers without punctuation\n    if presented in the form 123-456-7890 remove the hyphens and use 1234567890\n\n### Hints for Dates\n    All dates should be in the form YYYY-MM-DD and must include the dashes (-)\n    Date literals from the Grammar must NEVER be used\n    Date ranges should be finite and must include a start and end date\n\n### Hints for limits\n    Requests to resource change_event must specify a LIMIT of less than or equal to 10000\n\n### Hints for conversions questions\n    https://developers.google.com/google-ads/api/docs/conversions/upload-summaries \n\n\n### Hints for all resources\n    What follows is a list of valid resources that can be queried.\n    To find out which specific fields you can select, filter by, or sort by for a given resource, you MUST use the `get_resource_metadata` tool.\n    Do not guess the fields. Use the tool to look them up.\n    Once you have the fields, ensure the whole field name is used (e.g., 'campaign.id', not just 'id'). Wildcards and partial fields are not allowed.\n    accessible_bidding_strategy\naccount_budget\naccount_budget_proposal\naccount_link\nad\nad_group\nad_group_ad\nad_group_ad_asset_combination_view\nad_group_ad_asset_view\nad_group_ad_label\nad_group_asset\nad_group_asset_set\nad_group_audience_view\nad_group_bid_modifier\nad_group_criterion\nad_group_criterion_customizer\nad_group_criterion_label\nad_group_criterion_simulation\nad_group_customizer\nad_group_label\nad_group_simulation\nad_parameter\nad_schedule_view\nage_range_view\nai_max_search_term_ad_combination_view\nandroid_privacy_shared_key_google_ad_group\nandroid_privacy_shared_key_google_campaign\nandroid_privacy_shared_key_google_network_type\napplied_incentive\nasset\nasset_field_type_view\nasset_group\nasset_group_asset\nasset_group_listing_group_filter\nasset_group_product_group_view\nasset_group_signal\nasset_group_top_combination_view\nasset_set\nasset_set_asset\nasset_set_type_view\naudience\nbatch_job\nbidding_data_exclusion\nbidding_seasonality_adjustment\nbidding_strategy\nbidding_strategy_simulation\nbilling_setup\ncall_view\ncampaign\ncampaign_aggregate_asset_view\ncampaign_asset\ncampaign_asset_set\ncampaign_audience_view\ncampaign_bid_modifier\ncampaign_budget\ncampaign_conversion_goal\ncampaign_criterion\ncampaign_customizer\ncampaign_draft\ncampaign_goal_config\ncampaign_group\ncampaign_label\ncampaign_lifecycle_goal\ncampaign_search_term_insight\ncampaign_search_term_view\ncampaign_shared_set\ncampaign_simulation\ncarrier_constant\nchange_event\nchange_status\nchannel_aggregate_asset_view\nclick_view\ncombined_audience\ncontent_criterion_view\nconversion_action\nconversion_custom_variable\nconversion_goal_campaign_config\nconversion_value_rule\nconversion_value_rule_set\ncurrency_constant\ncustom_audience\ncustom_conversion_goal\ncustom_interest\ncustomer\ncustomer_asset\ncustomer_asset_set\ncustomer_client\ncustomer_client_link\ncustomer_conversion_goal\ncustomer_customizer\ncustomer_label\ncustomer_lifecycle_goal\ncustomer_manager_link\ncustomer_negative_criterion\ncustomer_search_term_insight\ncustomer_user_access\ncustomer_user_access_invitation\ncustomizer_attribute\ndata_link\ndetail_content_suitability_placement_view\ndetail_placement_view\ndetailed_demographic\ndisplay_keyword_view\ndistance_view\ndomain_category\ndynamic_search_ads_search_term_view\nexpanded_landing_page_view\nexperiment\nexperiment_arm\nfinal_url_expansion_asset_view\ngender_view\ngeo_target_constant\ngeographic_view\ngoal\ngroup_content_suitability_placement_view\ngroup_placement_view\nhotel_group_view\nhotel_performance_view\nhotel_reconciliation\nincome_range_view\nkeyword_plan\nkeyword_plan_ad_group\nkeyword_plan_ad_group_keyword\nkeyword_plan_campaign\nkeyword_plan_campaign_keyword\nkeyword_theme_constant\nkeyword_view\nlabel\nlanding_page_view\nlanguage_constant\nlead_form_submission_data\nlife_event\nlocal_services_employee\nlocal_services_lead\nlocal_services_lead_conversation\nlocal_services_verification_artifact\nlocation_interest_view\nlocation_view\nmanaged_placement_view\nmatched_location_interest_view\nmedia_file\nmobile_app_category_constant\nmobile_device_constant\noffline_conversion_upload_client_summary\noffline_conversion_upload_conversion_action_summary\noffline_user_data_job\noperating_system_version_constant\npaid_organic_search_term_view\nparental_status_view\nper_store_view\nperformance_max_placement_view\nproduct_category_constant\nproduct_group_view\nproduct_link\nproduct_link_invitation\nqualifying_question\nrecommendation\nrecommendation_subscription\nremarketing_action\nsearch_term_view\nshared_criterion\nshared_set\nshopping_performance_view\nshopping_product\nsmart_campaign_search_term_view\nsmart_campaign_setting\ntargeting_expansion_view\nthird_party_app_analytics_link\ntopic_constant\ntopic_view\ntravel_activity_group_view\ntravel_activity_performance_view\nuser_interest\nuser_list\nuser_list_customer_type\nuser_location_view\nvideo\nwebpage_view\nyou_tube_video_upload\n\n",
       "inputSchema": {
         "properties": {
-          "conditions": {
-            "default": null,
-            "items": {
-              "type": "string"
-            },
-            "title": "Conditions",
-            "type": "array"
-          },
           "customer_id": {
             "title": "Customer Id",
             "type": "string"
@@ -80,6 +2011,26 @@
               "type": "string"
             },
             "title": "Fields",
+            "type": "array"
+          },
+          "resource": {
+            "title": "Resource",
+            "type": "string"
+          },
+          "conditions": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "title": "Conditions",
+            "type": "array"
+          },
+          "orderings": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "title": "Orderings",
             "type": "array"
           },
           "limit": {
@@ -93,18 +2044,6 @@
             ],
             "default": null,
             "title": "Limit"
-          },
-          "orderings": {
-            "default": null,
-            "items": {
-              "type": "string"
-            },
-            "title": "Orderings",
-            "type": "array"
-          },
-          "resource": {
-            "title": "Resource",
-            "type": "string"
           }
         },
         "required": [
@@ -115,7 +2054,6 @@
         "title": "searchArguments",
         "type": "object"
       },
-      "name": "search",
       "outputSchema": {
         "properties": {
           "result": {
@@ -132,8 +2070,393 @@
         ],
         "title": "searchOutput",
         "type": "object"
+      }
+    },
+    {
+      "name": "set_campaign_status",
+      "description": "Enables, pauses, or removes a Google Ads campaign.\n\nThis is a convenience tool for quickly changing campaign status.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    campaign_id: The ID of the campaign.\n    status: The new status. One of: ENABLED, PAUSED, REMOVED.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the updated resource name and confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id",
+          "status"
+        ],
+        "title": "set_campaign_statusArguments",
+        "type": "object"
       },
-      "title": "Fetches data from the Google Ads API using the search method"
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "set_campaign_statusOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_ad_group",
+      "description": "Updates an existing ad group's settings.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    ad_group_id: The ID of the ad group to update.\n    name: New ad group name. Optional.\n    status: New status. One of: ENABLED, PAUSED, REMOVED. Optional.\n    cpc_bid_micros: New default max CPC bid in micros. Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the updated resource name and confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "ad_group_id": {
+            "title": "Ad Group Id",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Name"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Status"
+          },
+          "cpc_bid_micros": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Cpc Bid Micros"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "ad_group_id"
+        ],
+        "title": "update_ad_groupArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "update_ad_groupOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_ad_status",
+      "description": "Enables, pauses, or removes an ad.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    ad_group_id: The ID of the ad group containing the ad.\n    ad_id: The ID of the ad to update.\n    status: New status. One of: ENABLED, PAUSED, REMOVED.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the updated resource name and confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "ad_group_id": {
+            "title": "Ad Group Id",
+            "type": "string"
+          },
+          "ad_id": {
+            "title": "Ad Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "ad_group_id",
+          "ad_id",
+          "status"
+        ],
+        "title": "update_ad_statusArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "update_ad_statusOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_campaign",
+      "description": "Updates an existing Google Ads campaign's settings.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    campaign_id: The ID of the campaign to update.\n    name: New campaign name. Optional.\n    status: New status. One of: ENABLED, PAUSED, REMOVED. Optional.\n    budget_amount_micros: New daily budget in micros (e.g., 10000000 = $10.00). Optional.\n    start_date: New start date in YYYY-MM-DD format. Optional.\n    end_date: New end date in YYYY-MM-DD format. Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the updated resource names and a confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "campaign_id": {
+            "title": "Campaign Id",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Name"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Status"
+          },
+          "budget_amount_micros": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Budget Amount Micros"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "End Date"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "campaign_id"
+        ],
+        "title": "update_campaignArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": true,
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "update_campaignOutput",
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_keyword",
+      "description": "Updates a keyword's status or bid.\n\nArgs:\n    customer_id: The Google Ads customer ID (numbers only, no hyphens).\n    ad_group_id: The ID of the ad group containing the keyword.\n    criterion_id: The criterion ID of the keyword.\n    status: New status. One of: ENABLED, PAUSED, REMOVED. Optional.\n    cpc_bid_micros: New CPC bid in micros. Optional.\n    login_customer_id: The Manager Account ID for accessing client accounts via a manager. Optional.\n\nReturns:\n    Dictionary with the updated resource name and confirmation message.\n",
+      "inputSchema": {
+        "properties": {
+          "customer_id": {
+            "title": "Customer Id",
+            "type": "string"
+          },
+          "ad_group_id": {
+            "title": "Ad Group Id",
+            "type": "string"
+          },
+          "criterion_id": {
+            "title": "Criterion Id",
+            "type": "string"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Status"
+          },
+          "cpc_bid_micros": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Cpc Bid Micros"
+          },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Login Customer Id"
+          }
+        },
+        "required": [
+          "customer_id",
+          "ad_group_id",
+          "criterion_id"
+        ],
+        "title": "update_keywordArguments",
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Result",
+            "type": "object"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "update_keywordOutput",
+        "type": "object"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds **33 new tools** to the Google Ads MCP server, transforming it from read-only to a full campaign management platform. Rebased on latest main (post PR #37 merge). All tools follow existing code patterns and have been tested against live Google Ads accounts.

Supersedes #36 (rebased cleanly on top of #37's get_resource_metadata changes).

### Highlights
- **35 total tools** (2 original + get_resource_metadata from #37 + 32 new)
- **MCP Elicitation** for destructive operations (works on Claude Code CLI v2.1.81+, graceful fallback)
- **login_customer_id** parameter on all tools for Manager Account support
- **Lazy client initialization** for CI compatibility
- **EU political advertising compliance** (required since API v19.2)

## New tools by category

### Campaign Management (4 tools)
- `create_campaign` — Create Search/Display/Shopping campaigns with budgets and bidding strategies
- `create_performance_max_campaign` — Create PMax campaigns with brand assets via batch mutate
- `update_campaign` — Update campaign name, status, budget, and dates
- `set_campaign_status` — Quick enable/pause toggle

### Ad Group Management (2 tools)
- `create_ad_group` — Create ad groups with CPC bids and type settings
- `update_ad_group` — Update ad group name, status, and bids

### Ads & Keywords (7 tools)
- `create_responsive_search_ad` — Create RSAs with multiple headlines and descriptions
- `add_keywords` — Add keywords with match types (exact, phrase, broad) and optional bids
- `add_negative_keywords` — Add campaign-level negative keywords to block irrelevant traffic
- `update_ad_status` — Enable, pause, or remove ads
- `update_keyword` — Update keyword status or bid
- `remove_ad` — Permanently remove ads (**with MCP elicitation confirmation**)
- `remove_keyword` — Permanently remove keywords (**with MCP elicitation confirmation**)

### Targeting (2 tools)
- `set_geo_targets` — Set geographic targeting (countries/regions) for campaigns
- `set_ad_schedule` — Set day/hour ad scheduling for campaigns

### Asset Creation (10 tools)
- `create_text_asset`, `create_image_asset`, `create_youtube_video_asset`
- `create_sitelink_asset`, `create_callout_asset`, `create_structured_snippet_asset`
- `create_call_asset`, `create_promotion_asset`, `create_price_asset`, `create_lead_form_asset`

### Asset Linking (4 tools)
- `link_asset_to_campaign`, `link_asset_to_ad_group`, `link_assets_to_customer`
- `remove_campaign_asset` (**with MCP elicitation confirmation**)

### Asset Groups / Performance Max (3 tools)
- `create_asset_group`, `add_assets_to_asset_group`
- `remove_asset_from_asset_group` (**with MCP elicitation confirmation**)

## MCP Elicitation for Destructive Operations

All 4 destructive tools implement [MCP Elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation) with graceful fallback:

```python
@mcp.tool()
async def remove_keyword(
    customer_id: str, ad_group_id: str, criterion_id: str,
    ctx: Context = None,
) -> Dict[str, str]:
    result = await ctx.elicit(
        message="Permanently remove this keyword?",
        schema=Confirmation,
    )
    if result.action != "accept" or not result.data.confirm:
        return {"message": "Cancelled by user."}
```

Tested end-to-end on Claude Code CLI v2.1.81.

## Test plan

- [x] All 32 write tools tested against live Google Ads account (customer ID: 5293478735)
- [x] MCP elicitation confirmation verified on Claude Code CLI
- [x] PMax campaign creation with batch mutate (budget + campaign + brand assets)
- [x] Geo targeting set for US, UK, CA, AU, SG, UAE
- [x] Ad scheduling set for business hours
- [x] 55+ keywords added (exact/phrase/broad match)
- [x] 60+ negative keywords blocking irrelevant traffic
- [x] All 10 asset types created and linked to campaigns
- [x] Existing smoke tests, unit tests, and llm tests passing
- [x] Golden tools list updated to 35 tools