### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "google-ads-mcp"
 version = "0.0.1"
 requires-python = ">=3.10"
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 dependencies = [
     "google-ads>=30.0.0",
     "mcp[cli]>=1.2.0"


### PR DESCRIPTION
The repo’s pyproject.toml is not compliant with setuptools version. Specifically, "license": "Apache-2.0" is no longer accepted by stricter validators. As a result, MCP is disconnected.

The correct version should read: license = { text = "Apache-2.0" }

See: [https://github.com/googleads/google-ads-mcp/issues/41](https://github.com/googleads/google-ads-mcp/issues/41)