### PR TITLE
fix: handle proto.Message and repeated fields in format_output_value

### DIFF
--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -96,6 +96,10 @@ def get_googleads_client():
 def format_output_value(value: Any) -> Any:
     if isinstance(value, proto.Enum):
         return value.name
+    elif isinstance(value, proto.Message):
+        return proto.Message.to_dict(value)
+    elif isinstance(value, (list, tuple)):
+        return [format_output_value(item) for item in value]
     else:
         return value
 


### PR DESCRIPTION
Fixes #25

`format_output_value()` was only handling `proto.Enum` types. When a query returns fields like `responsive_search_ad.headlines` or `responsive_search_ad.descriptions`, the value is a `RepeatedCompositeContainer` (a list of proto messages), which isn't JSON-serializable as-is.

**Changes:**
- Added handling for `proto.Message` values using `proto.Message.to_dict()`
- Added recursive handling for `list` and `tuple` values so nested repeated fields are also serialized correctly
- Existing behavior for `proto.Enum` and plain scalars is unchanged

This lets the `search` tool handle RSA headlines/descriptions and other repeated composite fields without crashing.