### PR TITLE
fix: support OAuth 2.0 credentials alongside Application Default Credentials

### DIFF
--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -26,6 +26,7 @@ from google.ads.googleads.v23.services.services.google_ads_service import (
 
 from google.ads.googleads.util import get_nested_attr
 import google.auth
+from google.oauth2.credentials import Credentials as OAuth2Credentials
 from ads_mcp.mcp_header_interceptor import MCPHeaderInterceptor
 import os
 import importlib.resources
@@ -41,7 +42,26 @@ _READ_ONLY_ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
 
 
 def _create_credentials() -> google.auth.credentials.Credentials:
-    """Returns Application Default Credentials with read-only scope."""
+    """Returns credentials for the Google Ads API.
+
+    Uses OAuth 2.0 credentials when GOOGLE_ADS_CLIENT_ID,
+    GOOGLE_ADS_CLIENT_SECRET, and GOOGLE_ADS_REFRESH_TOKEN are all set.
+    Falls back to Application Default Credentials otherwise.
+    """
+    client_id = os.environ.get("GOOGLE_ADS_CLIENT_ID")
+    client_secret = os.environ.get("GOOGLE_ADS_CLIENT_SECRET")
+    refresh_token = os.environ.get("GOOGLE_ADS_REFRESH_TOKEN")
+
+    if client_id and client_secret and refresh_token:
+        return OAuth2Credentials(
+            token=None,
+            refresh_token=refresh_token,
+            token_uri="https://oauth2.googleapis.com/token",
+            client_id=client_id,
+            client_secret=client_secret,
+            scopes=[_READ_ONLY_ADS_SCOPE],
+        )
+
     credentials, _ = google.auth.default(scopes=[_READ_ONLY_ADS_SCOPE])
     return credentials
 


### PR DESCRIPTION
Fixes #16

`_create_credentials()` was unconditionally calling `google.auth.default()`, which only works in GCP environments with Application Default Credentials (service accounts, `gcloud auth application-default login`). The standard authentication flow for Google Ads API users is OAuth 2.0, using a client ID, client secret, and refresh token.

**Changes:**
- When `GOOGLE_ADS_CLIENT_ID`, `GOOGLE_ADS_CLIENT_SECRET`, and `GOOGLE_ADS_REFRESH_TOKEN` are all set as environment variables, OAuth 2.0 credentials are used
- Falls back to the existing `google.auth.default()` behavior when those variables aren't present, so existing setups are not broken

**Environment variables for OAuth 2.0:**
```
GOOGLE_ADS_CLIENT_ID
GOOGLE_ADS_CLIENT_SECRET
GOOGLE_ADS_REFRESH_TOKEN
GOOGLE_ADS_DEVELOPER_TOKEN  (already required)
GOOGLE_ADS_LOGIN_CUSTOMER_ID  (optional, already supported)
```