### PR TITLE
Implement the OAuth Proxy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,23 @@ to enable the following APIs in your Google Cloud project:
 * [Google Ads API](https://console.cloud.google.com/apis/library/googleads.googleapis.com)
 
 ### Configure Credentials
-#### Option 1: Configure credentials using Application Default Credentials
+#### Option 1: Using FastMCP OAuth Proxy
+
+The server supports FastMCP's [OAuth proxy](https://gofastmcp.com/servers/auth/oauth-proxy) feature for dynamic user authentication. This is useful when running the server as a web service.
+
+To enable it, set the following environment variables:
+
+- `GOOGLE_ADS_MCP_OAUTH_CLIENT_ID`: Your Google Cloud OAuth 2.0 Client ID.
+- `GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET`: Your Google Cloud OAuth 2.0 Client Secret.
+- `GOOGLE_ADS_MCP_BASE_URL`: (Optional) The base URL where the server is accessible (defaults to `http://localhost:8000`).
+
+Once this is enabled, you can authenticate to the API through your MCP client: for example, in Gemini CLI, the command `/mcp auth google-ads-mcp` triggers the authentication flow.
+
+When these variables are set, the server automatically switches to the `streamable-http` transport (SSE/HTTP) instead of stdio.
+
+You will need to run the server as a separate process and configure your MCP client to connect to the SSE endpoint (e.g., `http://localhost:8000/mcp`).
+
+#### Option 2: Configure credentials using Application Default Credentials
 
 Configure your [Application Default Credentials
 (ADC)](https://cloud.google.com/docs/authentication/provide-credentials-adc).
@@ -96,7 +112,7 @@ following message. You will need this for a later step!
 Credentials saved to file: [PATH_TO_CREDENTIALS_JSON]
 ```
 
-#### Option 2: Configure credentials using the Google Ads API Python client library.
+#### Option 3: Configure credentials using the Google Ads API Python client library.
 
 [Follow the instructions](https://developers.google.com/google-ads/api/docs/client-libs/python/)
 to setup and configure the Google Ads API Python client library
@@ -116,7 +132,26 @@ In the utils.py file, change get_googleads_client() to use the load_from_storage
     to the `mcpServers` list.
 
 
-- Option 1: the Application Default Credentials method
+- Option 1: Using FastMCP OAuth Proxy (Streamable HTTP)
+
+  You can run the server as a separate process and configure your MCP client to connect to the SSE endpoint (e.g., `http://localhost:8000/mcp`).
+  This also allows using FastMCP's [OAuth proxy](https://gofastmcp.com/servers/auth/oauth-proxy) feature for dynamic user authentication.
+
+    ```json
+    {
+      "mcpServers": {
+        "google-ads-mcp": {
+          "httpUrl":"http://localhost:8000/mcp",
+          "env": {
+            "GOOGLE_PROJECT_ID": "YOUR_PROJECT_ID",
+            "GOOGLE_ADS_DEVELOPER_TOKEN": "YOUR_DEVELOPER_TOKEN"                        
+          }
+        }
+      }
+    }
+    ```
+
+- Option 2: the Application Default Credentials method
 
     Replace `PATH_TO_CREDENTIALS_JSON` with the path you copied in the previous
     step.
@@ -149,7 +184,7 @@ In the utils.py file, change get_googleads_client() to use the load_from_storage
     }
     ```
 
-- Option 2: the Python client library method
+- Option 3: the Python client library method
 
     ```json
     {

--- a/ads_mcp/coordinator.py
+++ b/ads_mcp/coordinator.py
@@ -19,6 +19,26 @@ server using `@mcp.tool` annotations, thereby 'coordinating' the bootstrapping
 of the server.
 """
 
-from mcp.server.fastmcp import FastMCP
+import os
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.google import GoogleProvider
 
-mcp = FastMCP("Google Ads Server")
+_CLIENT_ID = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_ID")
+_CLIENT_SECRET = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET")
+_BASE_URL = os.environ.get("GOOGLE_ADS_MCP_BASE_URL", "http://localhost:8000")
+
+if _CLIENT_ID and _CLIENT_SECRET:
+    auth = GoogleProvider(
+        client_id=_CLIENT_ID,
+        client_secret=_CLIENT_SECRET,
+        base_url=_BASE_URL,
+        required_scopes=[
+            "openid",
+            "https://www.googleapis.com/auth/userinfo.email",
+            "https://www.googleapis.com/auth/userinfo.profile",
+            "https://www.googleapis.com/auth/adwords",
+        ],
+    )
+    mcp = FastMCP("Google Ads Server", auth=auth)
+else:
+    mcp = FastMCP("Google Ads Server")

--- a/ads_mcp/server.py
+++ b/ads_mcp/server.py
@@ -29,8 +29,17 @@ from ads_mcp.resources import (
 )  # noqa: F401
 
 
+import os
+
+
 def run_server() -> None:
-    mcp.run()
+    _CLIENT_ID = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_ID")
+    _CLIENT_SECRET = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET")
+
+    if _CLIENT_ID and _CLIENT_SECRET:
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run()
 
 
 if __name__ == "__main__":

--- a/ads_mcp/tools/search.py
+++ b/ads_mcp/tools/search.py
@@ -17,6 +17,8 @@
 from typing import Any, Dict, List
 from ads_mcp.coordinator import mcp
 import ads_mcp.utils as utils
+from google.ads.googleads.errors import GoogleAdsException
+from fastmcp.exceptions import ToolError
 
 
 def search(
@@ -57,17 +59,26 @@ def search(
     query = "".join(query_parts)
     utils.logger.info(f"ads_mcp.search query {query}")
 
-    query_result = ga_service.search_stream(
-        customer_id=customer_id, query=query
-    )
+    try:
+        query_result = ga_service.search_stream(
+            customer_id=customer_id, query=query
+        )
 
-    final_output: List = []
-    for batch in query_result:
-        for row in batch.results:
-            final_output.append(
-                utils.format_output_row(row, batch.field_mask.paths)
-            )
-    return final_output
+        final_output: List = []
+        for batch in query_result:
+            for row in batch.results:
+                final_output.append(
+                    utils.format_output_row(row, batch.field_mask.paths)
+                )
+        return final_output
+    except GoogleAdsException as ex:
+        error_msgs = [
+            f"Google Ads API Error: {error.message}"
+            for error in ex.failure.errors
+        ]
+        raise ToolError(
+            f"Request ID: {ex.request_id}\n" + "\n".join(error_msgs)
+        )
 
 
 def _search_tool_description() -> str:
@@ -122,8 +133,5 @@ def _search_tool_description() -> str:
 # runtime. Uses the `add_tool` method instead of an annnotation since `add_tool`
 # provides the flexibility needed to generate the description while also
 # including the `search` method's docstring.
-mcp.add_tool(
-    search,
-    title="Fetches data from the Google Ads API using the search method",
-    description=_search_tool_description(),
-)
+search.__doc__ = _search_tool_description()
+mcp.add_tool(search)

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -41,7 +41,15 @@ _READ_ONLY_ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
 
 
 def _create_credentials() -> google.auth.credentials.Credentials:
-    """Returns Application Default Credentials with read-only scope."""
+    """Returns Application Default Credentials with read-only scope or FastMCP token if found."""
+    from fastmcp.server.dependencies import get_access_token
+    from google.oauth2.credentials import Credentials
+
+    token_obj = get_access_token()
+    if token_obj and token_obj.token:
+        # Create credentials using the access token provided by FastMCP
+        return Credentials(token=token_obj.token)
+
     credentials, _ = google.auth.default(scopes=[_READ_ONLY_ADS_SCOPE])
     return credentials
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,11 @@
 name = "google-ads-mcp"
 version = "0.0.1"
 requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 dependencies = [
     "google-ads>=30.0.0",
-    "mcp[cli]>=1.2.0"
+    "mcp[cli]>=1.2.0",
+    "fastmcp>=3.2.0"
 ]
 
 description = "MCP Server for Google Ads, depends on Google Ads API."

--- a/tests/smoke/golden_resources_list.json
+++ b/tests/smoke/golden_resources_list.json
@@ -1,41 +1,61 @@
 {
   "resources": [
     {
+      "_meta": {
+        "fastmcp": {
+          "tags": []
+        }
+      },
       "annotations": {
         "idempotentHint": true,
         "readOnlyHint": true
       },
-      "description": "Retrieve the Google Ads API discovery document.\n\nProvides the discovery document for the Google Ads API v23, which\ndescribes the API surface, including resources, methods, and\nschemas.\nHost LLMs should access this resource to understand the structure of\nthe Google Ads API and discover available features.\n\nReturns:\n    str: The discovery document in JSON format.\n",
+      "description": "Retrieve the Google Ads API discovery document.\n\nProvides the discovery document for the Google Ads API v23, which\ndescribes the API surface, including resources, methods, and\nschemas.\nHost LLMs should access this resource to understand the structure of\nthe Google Ads API and discover available features.\n\nReturns:\n    str: The discovery document in JSON format.",
       "mimeType": "application/json",
       "name": "get_discovery_document",
       "uri": "resource://discovery-document"
     },
     {
+      "_meta": {
+        "fastmcp": {
+          "tags": []
+        }
+      },
       "annotations": {
         "idempotentHint": true,
         "readOnlyHint": true
       },
-      "description": "Retrieve the Google Ads API metrics documentation.\n\nProvides the official documentation for metrics in the Google Ads API,\nlisting all available metrics that can be queried to analyze performance\ndata.\nHost LLMs should access this resource to identify which metrics are\navailable and how they are calculated.\n\nReturns:\n    str: The metrics documentation in HTML format.\n",
+      "description": "Retrieve the Google Ads API metrics documentation.\n\nProvides the official documentation for metrics in the Google Ads API,\nlisting all available metrics that can be queried to analyze performance\ndata.\nHost LLMs should access this resource to identify which metrics are\navailable and how they are calculated.\n\nReturns:\n    str: The metrics documentation in HTML format.",
       "mimeType": "text/html",
       "name": "get_metrics",
       "uri": "resource://metrics"
     },
     {
+      "_meta": {
+        "fastmcp": {
+          "tags": []
+        }
+      },
       "annotations": {
         "idempotentHint": true,
         "readOnlyHint": true
       },
-      "description": "Retrieve the Google Ads API release notes.\n\nProvides the official release notes for the Google Ads API, detailing new\nfeatures, changes, deprecations, and bug fixes across all API versions.\nHost LLMs should access this resource to check for breaking changes,\ndetermine if a specific feature is supported in a given API version, or\ntroubleshoot issues by consulting recent API updates.\n\nReturns:\n    str: The release notes in HTML format.\n",
+      "description": "Retrieve the Google Ads API release notes.\n\nProvides the official release notes for the Google Ads API, detailing new\nfeatures, changes, deprecations, and bug fixes across all API versions.\nHost LLMs should access this resource to check for breaking changes,\ndetermine if a specific feature is supported in a given API version, or\ntroubleshoot issues by consulting recent API updates.\n\nReturns:\n    str: The release notes in HTML format.",
       "mimeType": "text/html",
       "name": "get_release_notes",
       "uri": "resource://release-notes"
     },
     {
+      "_meta": {
+        "fastmcp": {
+          "tags": []
+        }
+      },
       "annotations": {
         "idempotentHint": true,
         "readOnlyHint": true
       },
-      "description": "Retrieve the Google Ads API segments documentation.\n\nProvides the official documentation for segments in the Google Ads API,\ndetailing the available segments that can be used in GAQL queries to\npartition metrics.\nHost LLMs should access this resource to understand which segments\ncan be used with specific resources and metrics.\n\nReturns:\n    str: The segments documentation in HTML format.\n",
+      "description": "Retrieve the Google Ads API segments documentation.\n\nProvides the official documentation for segments in the Google Ads API,\ndetailing the available segments that can be used in GAQL queries to\npartition metrics.\nHost LLMs should access this resource to understand which segments\ncan be used with specific resources and metrics.\n\nReturns:\n    str: The segments documentation in HTML format.",
       "mimeType": "text/html",
       "name": "get_segments",
       "uri": "resource://segments"

--- a/tests/smoke/golden_tools_list.json
+++ b/tests/smoke/golden_tools_list.json
@@ -1,44 +1,43 @@
 {
   "tools": [
     {
+      "_meta": {
+        "fastmcp": {
+          "tags": []
+        }
+      },
       "annotations": {
         "readOnlyHint": true
       },
-      "description": "Retrieves the selectable, filterable, and sortable fields for a specific Google Ads resource.\n\nUse this tool to find out which fields you can select, filter by, or sort by\nwhen querying a specific resource (e.g., 'campaign', 'ad_group').\nDo not guess fields, you MUST use this tool to discover them.\n\nThe responses of this tool should be cached, as they don't change frequently.\n\nArgs:\n    resource_name: The name of the Google Ads resource (e.g., 'campaign', 'ad_group').\n",
+      "description": "Retrieves the selectable, filterable, and sortable fields for a specific Google Ads resource.\n\nUse this tool to find out which fields you can select, filter by, or sort by\nwhen querying a specific resource (e.g., 'campaign', 'ad_group').\nDo not guess fields, you MUST use this tool to discover them.\n\nThe responses of this tool should be cached, as they don't change frequently.\n\nArgs:\n    resource_name: The name of the Google Ads resource (e.g., 'campaign', 'ad_group').",
       "inputSchema": {
+        "additionalProperties": false,
         "properties": {
           "resource_name": {
-            "title": "Resource Name",
             "type": "string"
           }
         },
         "required": [
           "resource_name"
         ],
-        "title": "get_resource_metadataArguments",
         "type": "object"
       },
       "name": "get_resource_metadata",
       "outputSchema": {
-        "properties": {
-          "result": {
-            "additionalProperties": true,
-            "title": "Result",
-            "type": "object"
-          }
-        },
-        "required": [
-          "result"
-        ],
-        "title": "get_resource_metadataOutput",
+        "additionalProperties": true,
         "type": "object"
       }
     },
     {
+      "_meta": {
+        "fastmcp": {
+          "tags": []
+        }
+      },
       "description": "Returns ids of customers directly accessible by the user authenticating the call.",
       "inputSchema": {
+        "additionalProperties": false,
         "properties": {},
-        "title": "list_accessible_customersArguments",
         "type": "object"
       },
       "name": "list_accessible_customers",
@@ -48,38 +47,40 @@
             "items": {
               "type": "string"
             },
-            "title": "Result",
             "type": "array"
           }
         },
         "required": [
           "result"
         ],
-        "title": "list_accessible_customersOutput",
-        "type": "object"
+        "type": "object",
+        "x-fastmcp-wrap-result": true
       }
     },
     {
-      "description": "\nFetches data from the Google Ads API using the search method\n\nArgs:\n    customer_id: The id of the customer\n    fields: The fields to fetch\n    resource: The resource to return fields from\n    conditions: List of conditions to filter the data, combined using AND clauses\n    orderings: How the data is ordered\n    limit: The maximum number of rows to return\n\n\n\n### Hints\n    Language Grammar can be found at https://developers.google.com/google-ads/api/docs/query/grammar\n    All resources and descriptions are found at https://developers.google.com/google-ads/api/fields/v23/overview\n\n    For Conversion issues try looking in offline_conversion_upload_conversion_action_summary\n\n### Hint for customer_id\n    should be a string of numbers without punctuation\n    if presented in the form 123-456-7890 remove the hyphens and use 1234567890\n\n### Hints for Dates\n    All dates should be in the form YYYY-MM-DD and must include the dashes (-)\n    Date literals from the Grammar must NEVER be used\n    Date ranges should be finite and must include a start and end date\n\n### Hints for limits\n    Requests to resource change_event must specify a LIMIT of less than or equal to 10000\n\n### Hints for conversions questions\n    https://developers.google.com/google-ads/api/docs/conversions/upload-summaries \n\n\n### Hints for all resources\n    What follows is a list of valid resources that can be queried.\n    To find out which specific fields you can select, filter by, or sort by for a given resource, you MUST use the `get_resource_metadata` tool.\n    Do not guess the fields. Use the tool to look them up.\n    Once you have the fields, ensure the whole field name is used (e.g., 'campaign.id', not just 'id'). Wildcards and partial fields are not allowed.\n    accessible_bidding_strategy\naccount_budget\naccount_budget_proposal\naccount_link\nad\nad_group\nad_group_ad\nad_group_ad_asset_combination_view\nad_group_ad_asset_view\nad_group_ad_label\nad_group_asset\nad_group_asset_set\nad_group_audience_view\nad_group_bid_modifier\nad_group_criterion\nad_group_criterion_customizer\nad_group_criterion_label\nad_group_criterion_simulation\nad_group_customizer\nad_group_label\nad_group_simulation\nad_parameter\nad_schedule_view\nage_range_view\nai_max_search_term_ad_combination_view\nandroid_privacy_shared_key_google_ad_group\nandroid_privacy_shared_key_google_campaign\nandroid_privacy_shared_key_google_network_type\napplied_incentive\nasset\nasset_field_type_view\nasset_group\nasset_group_asset\nasset_group_listing_group_filter\nasset_group_product_group_view\nasset_group_signal\nasset_group_top_combination_view\nasset_set\nasset_set_asset\nasset_set_type_view\naudience\nbatch_job\nbidding_data_exclusion\nbidding_seasonality_adjustment\nbidding_strategy\nbidding_strategy_simulation\nbilling_setup\ncall_view\ncampaign\ncampaign_aggregate_asset_view\ncampaign_asset\ncampaign_asset_set\ncampaign_audience_view\ncampaign_bid_modifier\ncampaign_budget\ncampaign_conversion_goal\ncampaign_criterion\ncampaign_customizer\ncampaign_draft\ncampaign_goal_config\ncampaign_group\ncampaign_label\ncampaign_lifecycle_goal\ncampaign_search_term_insight\ncampaign_search_term_view\ncampaign_shared_set\ncampaign_simulation\ncarrier_constant\nchange_event\nchange_status\nchannel_aggregate_asset_view\nclick_view\ncombined_audience\ncontent_criterion_view\nconversion_action\nconversion_custom_variable\nconversion_goal_campaign_config\nconversion_value_rule\nconversion_value_rule_set\ncurrency_constant\ncustom_audience\ncustom_conversion_goal\ncustom_interest\ncustomer\ncustomer_asset\ncustomer_asset_set\ncustomer_client\ncustomer_client_link\ncustomer_conversion_goal\ncustomer_customizer\ncustomer_label\ncustomer_lifecycle_goal\ncustomer_manager_link\ncustomer_negative_criterion\ncustomer_search_term_insight\ncustomer_user_access\ncustomer_user_access_invitation\ncustomizer_attribute\ndata_link\ndetail_content_suitability_placement_view\ndetail_placement_view\ndetailed_demographic\ndisplay_keyword_view\ndistance_view\ndomain_category\ndynamic_search_ads_search_term_view\nexpanded_landing_page_view\nexperiment\nexperiment_arm\nfinal_url_expansion_asset_view\ngender_view\ngeo_target_constant\ngeographic_view\ngoal\ngroup_content_suitability_placement_view\ngroup_placement_view\nhotel_group_view\nhotel_performance_view\nhotel_reconciliation\nincome_range_view\nkeyword_plan\nkeyword_plan_ad_group\nkeyword_plan_ad_group_keyword\nkeyword_plan_campaign\nkeyword_plan_campaign_keyword\nkeyword_theme_constant\nkeyword_view\nlabel\nlanding_page_view\nlanguage_constant\nlead_form_submission_data\nlife_event\nlocal_services_employee\nlocal_services_lead\nlocal_services_lead_conversation\nlocal_services_verification_artifact\nlocation_interest_view\nlocation_view\nmanaged_placement_view\nmatched_location_interest_view\nmedia_file\nmobile_app_category_constant\nmobile_device_constant\noffline_conversion_upload_client_summary\noffline_conversion_upload_conversion_action_summary\noffline_user_data_job\noperating_system_version_constant\npaid_organic_search_term_view\nparental_status_view\nper_store_view\nperformance_max_placement_view\nproduct_category_constant\nproduct_group_view\nproduct_link\nproduct_link_invitation\nqualifying_question\nrecommendation\nrecommendation_subscription\nremarketing_action\nsearch_term_view\nshared_criterion\nshared_set\nshopping_performance_view\nshopping_product\nsmart_campaign_search_term_view\nsmart_campaign_setting\ntargeting_expansion_view\nthird_party_app_analytics_link\ntopic_constant\ntopic_view\ntravel_activity_group_view\ntravel_activity_performance_view\nuser_interest\nuser_list\nuser_list_customer_type\nuser_location_view\nvideo\nwebpage_view\nyou_tube_video_upload\n\n",
+      "_meta": {
+        "fastmcp": {
+          "tags": []
+        }
+      },
+      "description": "Fetches data from the Google Ads API using the search method\n\nArgs:\n    customer_id: The id of the customer\n    fields: The fields to fetch\n    resource: The resource to return fields from\n    conditions: List of conditions to filter the data, combined using AND clauses\n    orderings: How the data is ordered\n    limit: The maximum number of rows to return\n\n\n\n### Hints\n    Language Grammar can be found at https://developers.google.com/google-ads/api/docs/query/grammar\n    All resources and descriptions are found at https://developers.google.com/google-ads/api/fields/v23/overview\n\n    For Conversion issues try looking in offline_conversion_upload_conversion_action_summary\n\n### Hint for customer_id\n    should be a string of numbers without punctuation\n    if presented in the form 123-456-7890 remove the hyphens and use 1234567890\n\n### Hints for Dates\n    All dates should be in the form YYYY-MM-DD and must include the dashes (-)\n    Date literals from the Grammar must NEVER be used\n    Date ranges should be finite and must include a start and end date\n\n### Hints for limits\n    Requests to resource change_event must specify a LIMIT of less than or equal to 10000\n\n### Hints for conversions questions\n    https://developers.google.com/google-ads/api/docs/conversions/upload-summaries \n\n\n### Hints for all resources\n    What follows is a list of valid resources that can be queried.\n    To find out which specific fields you can select, filter by, or sort by for a given resource, you MUST use the `get_resource_metadata` tool.\n    Do not guess the fields. Use the tool to look them up.\n    Once you have the fields, ensure the whole field name is used (e.g., 'campaign.id', not just 'id'). Wildcards and partial fields are not allowed.\n    accessible_bidding_strategy\naccount_budget\naccount_budget_proposal\naccount_link\nad\nad_group\nad_group_ad\nad_group_ad_asset_combination_view\nad_group_ad_asset_view\nad_group_ad_label\nad_group_asset\nad_group_asset_set\nad_group_audience_view\nad_group_bid_modifier\nad_group_criterion\nad_group_criterion_customizer\nad_group_criterion_label\nad_group_criterion_simulation\nad_group_customizer\nad_group_label\nad_group_simulation\nad_parameter\nad_schedule_view\nage_range_view\nai_max_search_term_ad_combination_view\nandroid_privacy_shared_key_google_ad_group\nandroid_privacy_shared_key_google_campaign\nandroid_privacy_shared_key_google_network_type\napplied_incentive\nasset\nasset_field_type_view\nasset_group\nasset_group_asset\nasset_group_listing_group_filter\nasset_group_product_group_view\nasset_group_signal\nasset_group_top_combination_view\nasset_set\nasset_set_asset\nasset_set_type_view\naudience\nbatch_job\nbidding_data_exclusion\nbidding_seasonality_adjustment\nbidding_strategy\nbidding_strategy_simulation\nbilling_setup\ncall_view\ncampaign\ncampaign_aggregate_asset_view\ncampaign_asset\ncampaign_asset_set\ncampaign_audience_view\ncampaign_bid_modifier\ncampaign_budget\ncampaign_conversion_goal\ncampaign_criterion\ncampaign_customizer\ncampaign_draft\ncampaign_goal_config\ncampaign_group\ncampaign_label\ncampaign_lifecycle_goal\ncampaign_search_term_insight\ncampaign_search_term_view\ncampaign_shared_set\ncampaign_simulation\ncarrier_constant\nchange_event\nchange_status\nchannel_aggregate_asset_view\nclick_view\ncombined_audience\ncontent_criterion_view\nconversion_action\nconversion_custom_variable\nconversion_goal_campaign_config\nconversion_value_rule\nconversion_value_rule_set\ncurrency_constant\ncustom_audience\ncustom_conversion_goal\ncustom_interest\ncustomer\ncustomer_asset\ncustomer_asset_set\ncustomer_client\ncustomer_client_link\ncustomer_conversion_goal\ncustomer_customizer\ncustomer_label\ncustomer_lifecycle_goal\ncustomer_manager_link\ncustomer_negative_criterion\ncustomer_search_term_insight\ncustomer_user_access\ncustomer_user_access_invitation\ncustomizer_attribute\ndata_link\ndetail_content_suitability_placement_view\ndetail_placement_view\ndetailed_demographic\ndisplay_keyword_view\ndistance_view\ndomain_category\ndynamic_search_ads_search_term_view\nexpanded_landing_page_view\nexperiment\nexperiment_arm\nfinal_url_expansion_asset_view\ngender_view\ngeo_target_constant\ngeographic_view\ngoal\ngroup_content_suitability_placement_view\ngroup_placement_view\nhotel_group_view\nhotel_performance_view\nhotel_reconciliation\nincome_range_view\nkeyword_plan\nkeyword_plan_ad_group\nkeyword_plan_ad_group_keyword\nkeyword_plan_campaign\nkeyword_plan_campaign_keyword\nkeyword_theme_constant\nkeyword_view\nlabel\nlanding_page_view\nlanguage_constant\nlead_form_submission_data\nlife_event\nlocal_services_employee\nlocal_services_lead\nlocal_services_lead_conversation\nlocal_services_verification_artifact\nlocation_interest_view\nlocation_view\nmanaged_placement_view\nmatched_location_interest_view\nmedia_file\nmobile_app_category_constant\nmobile_device_constant\noffline_conversion_upload_client_summary\noffline_conversion_upload_conversion_action_summary\noffline_user_data_job\noperating_system_version_constant\npaid_organic_search_term_view\nparental_status_view\nper_store_view\nperformance_max_placement_view\nproduct_category_constant\nproduct_group_view\nproduct_link\nproduct_link_invitation\nqualifying_question\nrecommendation\nrecommendation_subscription\nremarketing_action\nsearch_term_view\nshared_criterion\nshared_set\nshopping_performance_view\nshopping_product\nsmart_campaign_search_term_view\nsmart_campaign_setting\ntargeting_expansion_view\nthird_party_app_analytics_link\ntopic_constant\ntopic_view\ntravel_activity_group_view\ntravel_activity_performance_view\nuser_interest\nuser_list\nuser_list_customer_type\nuser_location_view\nvideo\nwebpage_view\nyou_tube_video_upload",
       "inputSchema": {
+        "additionalProperties": false,
         "properties": {
           "conditions": {
             "default": null,
             "items": {
               "type": "string"
             },
-            "title": "Conditions",
             "type": "array"
           },
           "customer_id": {
-            "title": "Customer Id",
             "type": "string"
           },
           "fields": {
             "items": {
               "type": "string"
             },
-            "title": "Fields",
             "type": "array"
           },
           "limit": {
@@ -91,19 +92,16 @@
                 "type": "string"
               }
             ],
-            "default": null,
-            "title": "Limit"
+            "default": null
           },
           "orderings": {
             "default": null,
             "items": {
               "type": "string"
             },
-            "title": "Orderings",
             "type": "array"
           },
           "resource": {
-            "title": "Resource",
             "type": "string"
           }
         },
@@ -112,7 +110,6 @@
           "fields",
           "resource"
         ],
-        "title": "searchArguments",
         "type": "object"
       },
       "name": "search",
@@ -123,17 +120,15 @@
               "additionalProperties": true,
               "type": "object"
             },
-            "title": "Result",
             "type": "array"
           }
         },
         "required": [
           "result"
         ],
-        "title": "searchOutput",
-        "type": "object"
-      },
-      "title": "Fetches data from the Google Ads API using the search method"
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      }
     }
   ]
 }

--- a/tests/smoke/llm_sender.py
+++ b/tests/smoke/llm_sender.py
@@ -22,6 +22,22 @@ from google.genai import errors
 from tests.smoke import smoke_utils
 
 
+def _strip_additional_properties(schema: dict) -> dict:
+    """Recursively removes 'additionalProperties' and 'additional_properties' from the schema."""
+    if not isinstance(schema, dict):
+        return schema
+    for key, value in list(schema.items()):
+        if key in ("additionalProperties", "additional_properties"):
+            del schema[key]
+        elif isinstance(value, dict):
+            _strip_additional_properties(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    _strip_additional_properties(item)
+    return schema
+
+
 def get_llm_response(
     prompt: str | list, tools: list, include_usage: bool = False
 ) -> str | dict:
@@ -53,10 +69,14 @@ def get_llm_response(
         elif len(description) > 1024:
             description = description[:1024] + "..."
 
+        parameters = _strip_additional_properties(
+            dict(tool.get("inputSchema", {}))
+        )
+
         fd = types.FunctionDeclaration(
             name=tool["name"],
             description=description,
-            parameters=tool.get("inputSchema", {}),
+            parameters=parameters,
         )
         function_declarations.append(fd)
 

--- a/tests/smoke/smoke_utils.py
+++ b/tests/smoke/smoke_utils.py
@@ -23,11 +23,17 @@ from typing import Any, Dict, List, Optional
 
 def start_server_process() -> subprocess.Popen:
     """Starts the MCP server as a subprocess."""
+    # Ensure the server runs in stdio mode by clearing OAuth proxy env vars
+    env = os.environ.copy()
+    env.pop("GOOGLE_ADS_MCP_OAUTH_CLIENT_ID", None)
+    env.pop("GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET", None)
+
     return subprocess.Popen(
         [sys.executable, "-m", "ads_mcp.server"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=sys.stderr,
+        env=env,
         text=True,
         bufsize=0,  # Unbuffered
     )

--- a/tests/tools/search_test.py
+++ b/tests/tools/search_test.py
@@ -96,3 +96,42 @@ class TestSearch(unittest.TestCase):
                         description,
                     )
                     mock_log_error.assert_called_once()
+
+    @patch("ads_mcp.utils.get_googleads_service")
+    def test_search_google_ads_exception(self, mock_get_service):
+        """Tests that search handles GoogleAdsException and returns an error dict."""
+        from google.ads.googleads.errors import GoogleAdsException
+
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+
+        # Mock failure object
+        mock_error = MagicMock()
+        mock_error.message = "Invalid field name"
+        mock_failure = MagicMock()
+        mock_failure.errors = [mock_error]
+
+        # Instantiate real exception with dummy args
+        mock_ex = GoogleAdsException(
+            MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        )
+        mock_ex.failure = mock_failure
+        mock_ex.request_id = "req-123"
+
+        mock_service.search_stream.side_effect = mock_ex
+
+        # Call search and verify it raises ToolError
+        from fastmcp.exceptions import ToolError
+
+        with self.assertRaises(ToolError) as context:
+            search.search(
+                customer_id="1234567890",
+                fields=["invalid_field"],
+                resource="campaign",
+            )
+
+        # Verify error message
+        self.assertIn(
+            "Google Ads API Error: Invalid field name", str(context.exception)
+        )
+        self.assertIn("Request ID: req-123", str(context.exception))


### PR DESCRIPTION
This implements FastMCP's [OAuth proxy](https://gofastmcp.com/servers/auth/oauth-proxy) feature: it allows setting an OAuth clientID/clientSecret pair as environment variables in the MCP server and then performing the OAuth authentication flow from the MCP client, for instance running `/mcp auth google-ads-mcp` in Gemini CLI.

The changes included in this release are:
- Enabling the OAuth proxy if the `GOOGLE_ADS_MCP_OAUTH_CLIENT_ID` and 'GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET` environment variables are set and using the Streamable HTTP transport layer rather than STDIO, as it is required to use the OAuth proxy
- Document usage of the OAuth proxy feature
- Include the `fastmcp` dependency alongside the generic `mcp[cli]` one
- Update the test suite to use FastMCP-specific request and response formats
- Update the `search` tool to raise a `ToolError` when the client library raises a `GoogleAdsException` for additional clarity towards the MCP client