### PR TITLE
Fix repeated field serialization, add Keyword Planner tool, and add update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,42 @@ How many active campaigns do I have for customer id 1234567890
 ```
 
 
+## Updating
+
+The MCP server does not auto-update. When new changes are pushed to this repo,
+you need to update your local installation manually.
+
+### If you installed with `pipx run --spec git+...` (Gemini settings.json method)
+
+Re-install to pull the latest version:
+
+```shell
+pipx run --spec git+https://github.com/googleads/google-ads-mcp.git google-ads-mcp --version
+```
+
+If `pipx` caches the old version, clear it first:
+
+```shell
+pipx run --clear-cache
+```
+
+### If you installed from a local clone (`pipx install -e .`)
+
+Pull the latest changes and restart your client:
+
+```shell
+cd google-ads-mcp
+git pull
+```
+
+Since editable installs link directly to your local files, the changes take
+effect immediately — no reinstall needed.
+
+### After updating
+
+Restart your MCP client (Gemini CLI, Gemini Code Assist, Claude Code, etc.) to
+pick up the changes.
+
 ## Contributing
 
 Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md).

--- a/ads_mcp/server.py
+++ b/ads_mcp/server.py
@@ -20,7 +20,7 @@ from ads_mcp.coordinator import mcp
 # object, even though they are not directly used in this file.
 # The `# noqa: F401` comment tells the linter to ignore the "unused import"
 # warning.
-from ads_mcp.tools import search, core, get_resource_metadata  # noqa: F401
+from ads_mcp.tools import search, core, get_resource_metadata, keyword_planner  # noqa: F401
 from ads_mcp.resources import (
     discovery,
     metrics,

--- a/ads_mcp/tools/keyword_planner.py
+++ b/ads_mcp/tools/keyword_planner.py
@@ -1,0 +1,135 @@
+"""Keyword Planner tools for search volume and keyword ideas."""
+
+from typing import Any, Dict, List, Optional
+
+from ads_mcp.coordinator import mcp
+import ads_mcp.utils as utils
+
+
+def generate_keyword_ideas(
+    customer_id: str,
+    keywords: Optional[List[str]] = None,
+    page_url: Optional[str] = None,
+    language_id: str = "1000",
+    geo_target_ids: Optional[List[str]] = None,
+    include_adult_keywords: bool = False,
+    limit: int = 50,
+) -> List[Dict[str, Any]]:
+    """Generate keyword ideas with search volume and competition data.
+
+    Uses the Google Ads KeywordPlanIdeaService to get keyword suggestions
+    and historical metrics like monthly search volume and competition.
+
+    Args:
+        customer_id: The Google Ads customer ID (no hyphens, e.g. "1234567890").
+        keywords: Seed keywords to generate ideas from. At least one of
+            keywords or page_url must be provided.
+        page_url: A URL to generate keyword ideas from. At least one of
+            keywords or page_url must be provided.
+        language_id: Language criterion ID. Default "1000" (English).
+            Common values: 1000=English, 1003=Spanish, 1001=French,
+            1009=Portuguese, 1005=German, 1004=Italian.
+        geo_target_ids: List of geo target criterion IDs. Default ["2840"] (US).
+            Common values: 2840=US, 2826=UK, 2124=Canada, 2036=Australia,
+            2356=India, 2276=Germany, 2250=France, 2076=Brazil.
+        include_adult_keywords: Whether to include adult keywords.
+        limit: Maximum number of keyword ideas to return. Default 50.
+
+    Returns:
+        List of keyword idea dicts with fields: keyword, avg_monthly_searches,
+        competition, competition_index, low_top_of_page_bid_micros,
+        high_top_of_page_bid_micros, monthly_search_volumes.
+    """
+    if not keywords and not page_url:
+        raise ValueError("At least one of 'keywords' or 'page_url' must be provided.")
+
+    if geo_target_ids is None:
+        geo_target_ids = ["2840"]
+
+    service = utils.get_googleads_service("KeywordPlanIdeaService")
+    request = utils.get_googleads_type("GenerateKeywordIdeasRequest")
+
+    request.customer_id = customer_id
+    request.language = f"languageConstants/{language_id}"
+    request.include_adult_keywords = include_adult_keywords
+
+    for geo_id in geo_target_ids:
+        request.geo_target_constants.append(f"geoTargetConstants/{geo_id}")
+
+    request.keyword_plan_network = utils.get_googleads_type(
+        "KeywordPlanNetworkEnum"
+    ).KeywordPlanNetwork.GOOGLE_SEARCH_AND_PARTNERS
+
+    if keywords and page_url:
+        seed = request.keyword_and_url_seed
+        seed.url = page_url
+        for kw in keywords:
+            seed.keywords.append(kw)
+    elif keywords:
+        seed = request.keyword_seed
+        for kw in keywords:
+            seed.keywords.append(kw)
+    elif page_url:
+        request.url_seed.url = page_url
+
+    results = []
+    count = 0
+    for idea in service.generate_keyword_ideas(request=request):
+        if count >= limit:
+            break
+
+        metrics = idea.keyword_idea_metrics
+        monthly_volumes = []
+        if metrics.monthly_search_volumes:
+            for mv in metrics.monthly_search_volumes:
+                monthly_volumes.append({
+                    "year": mv.year,
+                    "month": mv.month.name if hasattr(mv.month, "name") else str(mv.month),
+                    "monthly_searches": mv.monthly_searches,
+                })
+
+        results.append({
+            "keyword": idea.text,
+            "avg_monthly_searches": metrics.avg_monthly_searches,
+            "competition": metrics.competition.name if hasattr(metrics.competition, "name") else str(metrics.competition),
+            "competition_index": metrics.competition_index,
+            "low_top_of_page_bid_micros": metrics.low_top_of_page_bid_micros,
+            "high_top_of_page_bid_micros": metrics.high_top_of_page_bid_micros,
+            "monthly_search_volumes": monthly_volumes[-12:] if monthly_volumes else [],
+        })
+        count += 1
+
+    return results
+
+
+_tool_description = """Generate keyword ideas with search volume and competition data.
+
+Uses the Google Ads KeywordPlanIdeaService to get keyword suggestions
+and historical metrics like monthly search volume and competition.
+
+Args:
+    customer_id: The Google Ads customer ID (no hyphens, e.g. "1234567890").
+    keywords: Seed keywords to generate ideas from. At least one of
+        keywords or page_url must be provided.
+    page_url: A URL to generate keyword ideas from. At least one of
+        keywords or page_url must be provided.
+    language_id: Language criterion ID. Default "1000" (English).
+        Common values: 1000=English, 1003=Spanish, 1001=French,
+        1009=Portuguese, 1005=German, 1004=Italian.
+    geo_target_ids: List of geo target criterion IDs. Default ["2840"] (US).
+        Common values: 2840=US, 2826=UK, 2124=Canada, 2036=Australia,
+        2356=India, 2276=Germany, 2250=France, 2076=Brazil.
+    include_adult_keywords: Whether to include adult keywords.
+    limit: Maximum number of keyword ideas to return. Default 50.
+
+Returns:
+    List of keyword idea dicts with fields: keyword, avg_monthly_searches,
+    competition, competition_index, low_top_of_page_bid_micros,
+    high_top_of_page_bid_micros, monthly_search_volumes.
+"""
+
+mcp.add_tool(
+    generate_keyword_ideas,
+    title="Generate Keyword Ideas",
+    description=_tool_description,
+)

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -25,6 +25,9 @@ from google.ads.googleads.v23.services.services.google_ads_service import (
 )
 
 from google.ads.googleads.util import get_nested_attr
+from google.protobuf.message import Message as ProtobufMessage
+from google.protobuf.json_format import MessageToDict
+from google._upb._message import RepeatedScalarContainer, RepeatedCompositeContainer
 import google.auth
 from ads_mcp.mcp_header_interceptor import MCPHeaderInterceptor
 import os
@@ -96,6 +99,12 @@ def get_googleads_client():
 def format_output_value(value: Any) -> Any:
     if isinstance(value, proto.Enum):
         return value.name
+    elif isinstance(value, RepeatedScalarContainer):
+        return list(value)
+    elif isinstance(value, RepeatedCompositeContainer):
+        return [MessageToDict(v) for v in value]
+    elif isinstance(value, ProtobufMessage):
+        return MessageToDict(value)
     else:
         return value
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -15,6 +15,7 @@
 """Test cases for the utils module."""
 
 import unittest
+import json
 from google.ads.googleads.v23.enums.types.campaign_status import (
     CampaignStatusEnum,
 )
@@ -34,3 +35,57 @@ class TestUtils(unittest.TestCase):
             ),
             "ENABLED",
         )
+
+    def test_format_output_value_repeated_scalar(self):
+        """Tests that repeated scalar fields (e.g. final_urls) are serialized to lists."""
+        client = utils.get_googleads_client()
+        ad_type = client.get_type("Ad")
+        ad_type.final_urls.append("https://www.example.com")
+        ad_type.final_urls.append("https://www.example.com/page2")
+
+        result = utils.format_output_value(ad_type.final_urls)
+        self.assertEqual(result, ["https://www.example.com", "https://www.example.com/page2"])
+        json.dumps(result)  # must be JSON-serializable
+
+    def test_format_output_value_empty_repeated(self):
+        """Tests that empty repeated fields serialize to empty lists."""
+        client = utils.get_googleads_client()
+        ad_type = client.get_type("Ad")
+
+        result = utils.format_output_value(ad_type.final_urls)
+        self.assertEqual(result, [])
+
+    def test_format_output_value_primitives(self):
+        """Tests that primitive types pass through unchanged."""
+        self.assertEqual(utils.format_output_value("hello"), "hello")
+        self.assertEqual(utils.format_output_value(42), 42)
+        self.assertEqual(utils.format_output_value(3.14), 3.14)
+        self.assertEqual(utils.format_output_value(True), True)
+
+    def test_format_output_value_proto_message(self):
+        """Tests that protobuf Message types are serialized to dicts."""
+        client = utils.get_googleads_client()
+        money_type = client.get_type("Money")
+        money_type.amount_micros = 5000000
+        money_type.currency_code = "USD"
+
+        result = utils.format_output_value(money_type)
+        self.assertIsInstance(result, dict)
+        json.dumps(result)  # must be JSON-serializable
+        self.assertEqual(result["currencyCode"], "USD")
+        self.assertEqual(result["amountMicros"], "5000000")
+
+    def test_format_output_value_repeated_composite(self):
+        """Tests that repeated composite fields (e.g. headlines) are serialized to list of dicts."""
+        client = utils.get_googleads_client()
+        ad_type = client.get_type("Ad")
+        headline = client.get_type("AdTextAsset")
+        headline.text = "Test Headline"
+        ad_type.responsive_search_ad.headlines.append(headline)
+
+        result = utils.format_output_value(ad_type.responsive_search_ad.headlines)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], dict)
+        self.assertEqual(result[0]["text"], "Test Headline")
+        json.dumps(result)  # must be JSON-serializable


### PR DESCRIPTION
## Summary
- **Fix `format_output_value()`** to handle repeated and message protobuf field types that previously caused `"Unable to serialize unknown type: RepeatedScalarContainer"` errors when querying fields like `ad.final_urls`, `ad.responsive_search_ad.headlines`, or any protobuf Message field
- **Add Keyword Planner tool** (`generate_keyword_ideas`) — wraps the `KeywordPlanIdeaService` to generate keyword ideas with search volume, competition data, and bid estimates. Supports seed keywords and/or page URL, language/geo targeting, and configurable result limits
- **Add update instructions** to README so users know how to pull in new changes

## Test plan
- [x] Added unit tests for repeated scalar, repeated composite, protobuf message, empty repeated, and primitive pass-through cases
- [ ] Manual verification: query `ad_group_ad.ad.final_urls` via the MCP search tool and confirm it returns a JSON list instead of erroring
- [ ] Manual verification: call `generate_keyword_ideas` with seed keywords and confirm results include search volume and competition data

🤖 Generated with [Claude Code](https://claude.com/claude-code)