### PR TITLE
Remove unused imports and replace bare except clauses

### DIFF
--- a/ads_mcp/mcp_header_interceptor.py
+++ b/ads_mcp/mcp_header_interceptor.py
@@ -35,7 +35,7 @@ class MCPHeaderInterceptor(
         """
         try:
             return metadata.version("google-ads-mcp")
-        except:
+        except Exception:
             return "unknown"
 
     _MCP_EXTRA_HEADER = (
@@ -82,7 +82,7 @@ class MCPHeaderInterceptor(
                 metadata=metadata
             )
             return continuation(new_client_call_details, request)
-        except:
+        except Exception:
             logger.error("Error in MCPHeaderInterceptor", exc_info=True)
             return continuation(client_call_details, request)
 

--- a/ads_mcp/tools/get_resource_metadata.py
+++ b/ads_mcp/tools/get_resource_metadata.py
@@ -14,7 +14,7 @@
 
 """Tools for fetching metadata for Google Ads resources."""
 
-from typing import Dict, List, Any
+from typing import Any, Dict
 from ads_mcp.coordinator import mcp
 from mcp.types import ToolAnnotations
 import ads_mcp.utils as utils

--- a/ads_mcp/update_references.py
+++ b/ads_mcp/update_references.py
@@ -15,8 +15,6 @@
 """Tools for generating file containing a list of resources and their fields."""
 
 import utils
-import json
-import collections
 
 
 def update_gaql_resource_file():


### PR DESCRIPTION
## Summary

- Remove unused `json` and `collections` imports from `update_references.py`
- Remove unused `List` import from `get_resource_metadata.py` (only `Dict` and `Any` are used)
- Replace bare `except:` with `except Exception:` in `mcp_header_interceptor.py` (PEP 8 E722)

## Details

All changes are mechanical cleanup — no behavior changes.

The bare `except:` clauses catch `BaseException` subclasses like `KeyboardInterrupt` and `SystemExit`, which should propagate. `except Exception:` is the standard Python practice per [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations).

## Test plan

- [ ] Existing unit tests pass (`nox -s tests`)
- [ ] `black -l 80` reports no formatting changes