### PR TITLE
Update stale v21 API references to v24

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains the source code for running a local
 ## Tools
 
 The server uses the
-[Google Ads API](https://developers.google.com/google-ads/api/reference/rpc/v21/overview)
+[Google Ads API](https://developers.google.com/google-ads/api/reference/rpc/v24/overview)
 to provide several
 [Tools](https://modelcontextprotocol.io/docs/concepts/tools) for use with LLMs.
 

--- a/ads_mcp/tools/core.py
+++ b/ads_mcp/tools/core.py
@@ -19,7 +19,7 @@ from ads_mcp.coordinator import mcp
 
 import ads_mcp.utils as utils
 
-from google.ads.googleads.v21.services.types.customer_service import (
+from google.ads.googleads.v24.services.types.customer_service import (
     ListAccessibleCustomersResponse,
 )
 


### PR DESCRIPTION
## Summary

- Update `core.py` import from `google.ads.googleads.v21` to `v24` to match the rest of the codebase (`utils.py`, test files)
- Update README API reference link from v21 to v24

## Details

`utils.py:23` and both test files import from `v24`, but `tools/core.py:22` still imports `ListAccessibleCustomersResponse` from `v21`. The README link on line 10 also pointed to the v21 reference docs.

The `pyproject.toml` requires `google-ads>=30.1.0`, which ships v24.

## Test plan

- [ ] Existing unit tests pass (`nox -s tests`)
- [ ] `list_accessible_customers` tool still works against a live account