### PR TITLE
Annotate search and list_accessible_customers as readOnlyHint

### DIFF
--- a/ads_mcp/tools/core.py
+++ b/ads_mcp/tools/core.py
@@ -16,6 +16,7 @@
 
 from typing import List
 from ads_mcp.coordinator import mcp
+from mcp.types import ToolAnnotations
 
 import ads_mcp.utils as utils
 
@@ -24,7 +25,7 @@ from google.ads.googleads.v24.services.types.customer_service import (
 )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 def list_accessible_customers() -> List[str]:
     """Returns ids of customers directly accessible by the user authenticating the call.
 

--- a/ads_mcp/tools/search.py
+++ b/ads_mcp/tools/search.py
@@ -16,6 +16,8 @@
 
 from typing import Any, Dict, List
 from ads_mcp.coordinator import mcp
+from fastmcp.tools import Tool
+from mcp.types import ToolAnnotations
 import ads_mcp.utils as utils
 from google.ads.googleads.errors import GoogleAdsException
 from fastmcp.exceptions import ToolError
@@ -136,4 +138,6 @@ def _search_tool_description() -> str:
 # provides the flexibility needed to generate the description while also
 # including the `search` method's docstring.
 search.__doc__ = _search_tool_description()
-mcp.add_tool(search)
+mcp.add_tool(
+    Tool.from_function(search, annotations=ToolAnnotations(readOnlyHint=True))
+)

--- a/tests/smoke/golden_tools_list.json
+++ b/tests/smoke/golden_tools_list.json
@@ -35,6 +35,9 @@
           "tags": []
         }
       },
+      "annotations": {
+        "readOnlyHint": true
+      },
       "description": "Returns ids of customers directly accessible by the user authenticating the call.\n\nUse this tool first to discover available customer IDs if the user hasn't\nprovided one. Most other tools require a valid customer ID as input.\n\nReturns:\n    List[str]: A list of customer IDs.",
       "inputSchema": {
         "additionalProperties": false,
@@ -63,6 +66,9 @@
         "fastmcp": {
           "tags": []
         }
+      },
+      "annotations": {
+        "readOnlyHint": true
       },
       "description": "Fetches data from the Google Ads API using the search method",
       "inputSchema": {


### PR DESCRIPTION
## Summary

The `search` and `list_accessible_customers` tools only invoke read methods on the Google Ads API, but only `get_resource_metadata` was declaring `ToolAnnotations(readOnlyHint=True)`. MCP clients surface this hint to users (and some hosts use it to gate tool calls), so all three tools should declare it consistently.

## Changes

- `ads_mcp/tools/core.py`: add `ToolAnnotations(readOnlyHint=True)` to `list_accessible_customers`.
- `ads_mcp/tools/search.py`: register `search` via `Tool.from_function(..., annotations=ToolAnnotations(readOnlyHint=True))` since `mcp.add_tool` does not accept annotations directly.
- `tests/smoke/golden_tools_list.json`: refreshed via `python -m tests.smoke.generate_golden` so the smoke test still passes; only the two new `annotations` blocks change.

## Test plan

- [x] `python -m unittest discover --buffer -s tests -p "*_test.py"` — 18/18 pass
- [x] `black -l 80 --check ads_mcp tests` — clean
- [x] Verified the regenerated golden diff is limited to the two added `annotations` blocks