### PR TITLE
Correct misleading scope comment and constant name in utils

### DIFF
--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -36,12 +36,14 @@ _GAQL_FILENAME = "gaql_resources.txt"
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-# Read-only scope for Analytics Admin API and Analytics Data API.
-_READ_ONLY_ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
+# OAuth scope for the Google Ads API. Google Ads does not publish a separate
+# read-only scope; access is restricted to read methods by the tools this
+# server exposes (see ads_mcp/tools/).
+_ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
 
 
 def _create_credentials() -> google.auth.credentials.Credentials:
-    """Returns Application Default Credentials with read-only scope or FastMCP token if found."""
+    """Returns Application Default Credentials with the Google Ads scope, or the FastMCP token if found."""
     from fastmcp.server.dependencies import get_access_token
     from google.oauth2.credentials import Credentials
 
@@ -50,7 +52,7 @@ def _create_credentials() -> google.auth.credentials.Credentials:
         # Create credentials using the access token provided by FastMCP
         return Credentials(token=token_obj.token)
 
-    credentials, _ = google.auth.default(scopes=[_READ_ONLY_ADS_SCOPE])
+    credentials, _ = google.auth.default(scopes=[_ADS_SCOPE])
     return credentials
 
 


### PR DESCRIPTION
## Summary

The comment above the private OAuth scope constant in [ads_mcp/utils.py](ads_mcp/utils.py) describes it as the scope for the Analytics Admin and Analytics Data APIs, but the value is in fact the Google Ads scope (\`https://www.googleapis.com/auth/adwords\`). It also labels the scope read-only — Google Ads does not publish a separate read-only variant; the server is read-only because of the tools it exposes, not the scope.

## Changes

- Replace the comment with an accurate description.
- Rename \`_READ_ONLY_ADS_SCOPE\` → \`_ADS_SCOPE\`.
- Tighten the docstring on \`_create_credentials\` to match.

No behavior changes — the scope value is unchanged.

## Test plan

- [x] \`python -m unittest discover --buffer -s tests -p \"*_test.py\"\` — 18/18 pass
- [x] \`black -l 80 --check ads_mcp tests\` — clean
- [x] \`grep -rn _READ_ONLY_ADS_SCOPE\` — no remaining references