### PR TITLE
fix: update limit type hint to int in search tool

### DIFF
--- a/ads_mcp/tools/search.py
+++ b/ads_mcp/tools/search.py
@@ -29,7 +29,7 @@ def search(
     resource: str,
     conditions: List[str] = None,
     orderings: List[str] = None,
-    limit: int | str = None,
+    limit: int = None,
 ) -> List[Dict[str, Any]]:
     """Fetches data from the Google Ads API using the search method
 

--- a/tests/smoke/golden_tools_list.json
+++ b/tests/smoke/golden_tools_list.json
@@ -94,16 +94,9 @@
             "type": "array"
           },
           "limit": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              }
-            ],
             "default": null,
-            "description": "The maximum number of rows to return"
+            "description": "The maximum number of rows to return",
+            "type": "integer"
           },
           "orderings": {
             "default": null,


### PR DESCRIPTION
While deploying on Cloud Run (GCP) the usage of VertexAI requires strict types. This PR  fixes the issue