### PR TITLE
docs: add GOOGLE_ADS_LOGIN_CUSTOMER_ID to Cloud Run deployment env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Make sure to set the required environment variables:
 - `GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET`: The OAuth Client secret you want the MCP server to use.
 - `GOOGLE_ADS_MCP_BASE_URL`: The base URL where your MCP server is accessible: this will be automatically assigned by Google Cloud Run after your first deployment. You can update the environment variables after deployment. 
 - `FASTMCP_HOST`: Set this to `0.0.0.0` to allow FastMCP to accept connections from all IP addresses.
+- `GOOGLE_ADS_LOGIN_CUSTOMER_ID` *(MCC accounts only)*: The customer ID of your manager account. Required when accessing client accounts through a Google Ads Manager (MCC) account.
 
 ```shell
 gcloud run deploy google-ads-mcp \


### PR DESCRIPTION
## Summary
- Added `GOOGLE_ADS_LOGIN_CUSTOMER_ID` as a conditional environment variable in the Google Cloud Run deployment section of the README
- Marked it as MCC accounts only, with a brief explanation that it is required when accessing client accounts through a Google Ads Manager (MCC) account

## Test plan
- [ ] Review the README Cloud Run deployment section to confirm the new bullet point is accurate and consistent with the local setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)