### PR TITLE
feat: opt-in write tools (create, update, remove)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ to provide several
 - `list_accessible_customers`: Returns ids of customers directly accessible
   by the user authenticating the call.
 
+### Optional write tools (opt-in, off by default)
+
+Set environment variables before starting the server (for example in your MCP
+client `env` block). Write tools are registered when the server process starts.
+
+| Variable | Effect |
+|----------|--------|
+| `GOOGLE_ADS_MCP_ENABLE_MUTATE=1` | Enables `create` and `update` |
+| `GOOGLE_ADS_MCP_ENABLE_REMOVE=1` | Enables `remove` (requires mutate enabled) |
+| `GOOGLE_ADS_MCP_MUTATE_CHUNK_SIZE` | Operations per mutate request (default `500`) |
+
+- `create` / `update` / `remove`: call `GoogleAdsService.mutate` with
+  [MutateOperation](https://developers.google.com/google-ads/api/rest/reference/rest/latest/MutateOperation)
+  objects (API JSON, camelCase). Supports `validate_only` and server-side chunking.
+- **Warning:** write tools can change your Google Ads account. Use test accounts
+  and `validate_only=true` first.
+
+See [issue #84](https://github.com/googleads/google-ads-mcp/issues/84) for the
+upstream proposal discussion.
+
 ### Resources available
 
 - `discovery-document`: Retrieve the Google Ads API discovery document. Provides the discovery document for the latest version of the Google Ads API, which describes the API surface, including resources, methods, and schemas. Host LLMs should access this resource to understand the structure of the Google Ads API and discover available features.

--- a/ads_mcp/feature_flags.py
+++ b/ads_mcp/feature_flags.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment-gated feature flags for optional MCP tools."""
+
+import os
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _env_truthy(name: str) -> bool:
+    """Returns whether an environment variable is set to a truthy value.
+
+    Args:
+        name: The environment variable name.
+
+    Returns:
+        True if the value is one of 1, true, yes, or on (case insensitive).
+    """
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def is_mutate_enabled() -> bool:
+    """Checks whether write tools are enabled.
+
+    Returns:
+        True if GOOGLE_ADS_MCP_ENABLE_MUTATE is set to a truthy value.
+    """
+    return _env_truthy("GOOGLE_ADS_MCP_ENABLE_MUTATE")
+
+
+def is_remove_enabled() -> bool:
+    """Checks whether the remove tool is enabled.
+
+    Returns:
+        True if mutate is enabled and GOOGLE_ADS_MCP_ENABLE_REMOVE is truthy.
+    """
+    return is_mutate_enabled() and _env_truthy("GOOGLE_ADS_MCP_ENABLE_REMOVE")
+
+
+def mutate_chunk_size() -> int:
+    """Returns the maximum number of operations per mutate request.
+
+    Returns:
+        A positive integer from GOOGLE_ADS_MCP_MUTATE_CHUNK_SIZE, default 500.
+
+    Raises:
+        ValueError: If the environment variable is not a positive integer.
+    """
+    raw = os.environ.get("GOOGLE_ADS_MCP_MUTATE_CHUNK_SIZE", "500")
+    try:
+        size = int(raw)
+    except ValueError as ex:
+        raise ValueError(
+            "GOOGLE_ADS_MCP_MUTATE_CHUNK_SIZE must be a positive integer."
+        ) from ex
+    if size < 1:
+        raise ValueError(
+            "GOOGLE_ADS_MCP_MUTATE_CHUNK_SIZE must be a positive integer."
+        )
+    return size

--- a/ads_mcp/server.py
+++ b/ads_mcp/server.py
@@ -21,6 +21,7 @@ from ads_mcp.coordinator import mcp
 # The `# noqa: F401` comment tells the linter to ignore the "unused import"
 # warning.
 from ads_mcp.tools import search, core, get_resource_metadata  # noqa: F401
+from ads_mcp.tools import write_registration  # noqa: F401
 from ads_mcp.resources import (
     discovery,
     metrics,
@@ -33,6 +34,7 @@ import os
 
 
 def run_server() -> None:
+    write_registration.register_write_tools()
     _CLIENT_ID = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_ID")
     _CLIENT_SECRET = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET")
     port = int(os.environ.get("PORT", "8080"))

--- a/ads_mcp/tools/create.py
+++ b/ads_mcp/tools/create.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for exposing Google Ads mutate create operations to the MCP server."""
+
+from typing import Any, Dict, List
+
+from ads_mcp.coordinator import mcp
+from ads_mcp.tools import mutate_core
+from fastmcp.tools import Tool
+
+
+def create(
+    customer_id: str,
+    operations: List[Dict[str, Any]],
+    validate_only: bool = False,
+    partial_failure: bool = True,
+) -> Dict[str, Any]:
+    """Creates Google Ads resources using MutateOperation create clauses.
+
+    Each operation must use a nested *Operation message with a create field,
+    such as campaignOperation.create or adGroupOperation.create.
+
+    Args:
+        customer_id: The Google Ads customer ID.
+        operations: A list of MutateOperation objects in API JSON form.
+        validate_only: If True, validates the request without applying changes.
+        partial_failure: If True, allows successful operations when some fail.
+
+    Returns:
+        A dict of mutate results from GoogleAdsService.mutate.
+
+    Raises:
+        ToolError: If the request is invalid or the API returns an error.
+    """
+    return mutate_core.execute_mutate(
+        customer_id=customer_id,
+        operations=operations,
+        validate_only=validate_only,
+        partial_failure=partial_failure,
+    )
+
+
+def _create_tool_description() -> str:
+    """Returns the description for the `create` tool."""
+    return f"""
+{create.__doc__}
+{mutate_core._mutate_operations_hints()}
+"""
+
+
+create.__doc__ = _create_tool_description()
+mcp.add_tool(Tool.from_function(create))

--- a/ads_mcp/tools/mutate_core.py
+++ b/ads_mcp/tools/mutate_core.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared GoogleAdsService.mutate execution for write MCP tools."""
+
+from typing import Any, Dict, List
+
+from fastmcp.exceptions import ToolError
+from google.ads.googleads.errors import GoogleAdsException
+from google.protobuf import json_format
+
+import ads_mcp.feature_flags as feature_flags
+import ads_mcp.utils as utils
+
+
+def _normalize_customer_id(customer_id: str) -> str:
+    """Strips hyphens and whitespace from a customer ID string.
+
+    Args:
+        customer_id: The customer ID, optionally formatted with hyphens.
+
+    Returns:
+        The customer ID containing digits only.
+    """
+    return customer_id.replace("-", "").strip()
+
+
+def _parse_operations(
+    operation_dicts: List[Dict[str, Any]],
+) -> List[Any]:
+    """Builds MutateOperation protos from REST-style JSON dicts.
+
+    Args:
+        operation_dicts: A list of MutateOperation objects using camelCase keys
+            as in the Google Ads API REST reference.
+
+    Returns:
+        A list of MutateOperation proto-plus messages.
+
+    Raises:
+        ToolError: If an entry is not a dict or cannot be parsed as protobuf
+            JSON.
+    """
+    operations = []
+    for index, op_dict in enumerate(operation_dicts):
+        if not isinstance(op_dict, dict):
+            raise ToolError(
+                f"Operation at index {index} must be an object, got "
+                f"{type(op_dict).__name__}."
+            )
+        mutate_operation = utils.get_googleads_type("MutateOperation")
+        try:
+            json_format.ParseDict(
+                op_dict,
+                mutate_operation._pb,
+                ignore_unknown_fields=False,
+            )
+        except json_format.ParseError as ex:
+            raise ToolError(
+                f"Invalid MutateOperation at index {index}: {ex}"
+            ) from ex
+        operations.append(mutate_operation)
+    return operations
+
+
+def _raise_google_ads_exception(ex: GoogleAdsException) -> None:
+    """Raises a ToolError that includes the Google Ads API error details.
+
+    Args:
+        ex: The GoogleAdsException raised by the API client.
+
+    Raises:
+        ToolError: Always raised with the request ID and error messages.
+    """
+    error_msgs = [
+        f"Google Ads API Error: {error.message}" for error in ex.failure.errors
+    ]
+    raise ToolError(f"Request ID: {ex.request_id}\n" + "\n".join(error_msgs))
+
+
+def execute_mutate(
+    customer_id: str,
+    operations: List[Dict[str, Any]],
+    validate_only: bool = False,
+    partial_failure: bool = True,
+) -> Dict[str, Any]:
+    """Executes GoogleAdsService.mutate with server-side chunking.
+
+    Args:
+        customer_id: The Google Ads customer ID.
+        operations: MutateOperation payloads in API JSON form (camelCase).
+        validate_only: If True, validates the request without applying changes.
+        partial_failure: If True, allows successful operations when some fail.
+
+    Returns:
+        A dict with key mutate_operation_responses. Includes
+        partial_failure_error when the API reports partial failures.
+
+    Raises:
+        ToolError: If operations is empty, parsing fails, or the API returns an
+            error.
+    """
+    if not operations:
+        raise ToolError("At least one MutateOperation is required.")
+
+    customer_id = _normalize_customer_id(customer_id)
+    parsed = _parse_operations(operations)
+    chunk_size = feature_flags.mutate_chunk_size()
+    ga_service = utils.get_googleads_service("GoogleAdsService")
+    request = utils.get_googleads_type("MutateGoogleAdsRequest")
+    request.customer_id = customer_id
+    request.validate_only = validate_only
+    request.partial_failure = partial_failure
+
+    aggregated_responses: List[Any] = []
+    last_partial_failure: Any = None
+
+    for start in range(0, len(parsed), chunk_size):
+        chunk = parsed[start : start + chunk_size]
+        del request.mutate_operations[:]
+        request.mutate_operations.extend(chunk)
+        utils.logger.info(
+            "ads_mcp.mutate customer_id=%s validate_only=%s "
+            "partial_failure=%s operations=%s",
+            customer_id,
+            validate_only,
+            partial_failure,
+            len(chunk),
+        )
+        try:
+            response = ga_service.mutate(request=request)
+        except GoogleAdsException as ex:
+            _raise_google_ads_exception(ex)
+
+        aggregated_responses.extend(
+            [
+                utils.format_output_value(r)
+                for r in response.mutate_operation_responses
+            ]
+        )
+        if response.partial_failure_error:
+            last_partial_failure = response.partial_failure_error
+
+    result: Dict[str, Any] = {
+        "mutate_operation_responses": aggregated_responses,
+    }
+    if last_partial_failure:
+        result["partial_failure_error"] = utils.format_output_value(
+            last_partial_failure
+        )
+    return result
+
+
+def _mutate_operations_hints() -> str:
+    """Returns hint text appended to write tool descriptions."""
+    return """
+### Hints for operations
+    Each item is one MutateOperation in Google Ads API JSON form (camelCase):
+    https://developers.google.com/google-ads/api/rest/reference/rest/latest/MutateOperation
+
+    Examples:
+    - Update: {"campaignOperation": {"update": {"resourceName": "...", "status": "PAUSED"}, "updateMask": "status"}}
+    - Create: {"campaignOperation": {"create": {...}}}
+    - Remove: {"campaignOperation": {"remove": "customers/.../campaigns/..."}}
+
+    Use get_resource_metadata before updates. Prefer validate_only=true to dry-run.
+
+### Hint for customer_id
+    Should be a string of numbers without punctuation.
+    If presented as 123-456-7890, use 1234567890.
+"""

--- a/ads_mcp/tools/remove.py
+++ b/ads_mcp/tools/remove.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for exposing Google Ads mutate remove operations to the MCP server."""
+
+from typing import Any, Dict, List
+
+from ads_mcp.coordinator import mcp
+from ads_mcp.tools import mutate_core
+from fastmcp.tools import Tool
+from mcp.types import ToolAnnotations
+
+
+def remove(
+    customer_id: str,
+    operations: List[Dict[str, Any]],
+    validate_only: bool = False,
+    partial_failure: bool = True,
+) -> Dict[str, Any]:
+    """Removes Google Ads resources using MutateOperation remove clauses.
+
+    Each operation must use a nested *Operation message with a remove field
+    set to the resource name, such as campaignOperation.remove.
+
+    Args:
+        customer_id: The Google Ads customer ID.
+        operations: A list of MutateOperation objects in API JSON form.
+        validate_only: If True, validates the request without applying changes.
+        partial_failure: If True, allows successful operations when some fail.
+
+    Returns:
+        A dict of mutate results from GoogleAdsService.mutate.
+
+    Raises:
+        ToolError: If the request is invalid or the API returns an error.
+    """
+    return mutate_core.execute_mutate(
+        customer_id=customer_id,
+        operations=operations,
+        validate_only=validate_only,
+        partial_failure=partial_failure,
+    )
+
+
+def _remove_tool_description() -> str:
+    """Returns the description for the `remove` tool."""
+    return f"""
+{remove.__doc__}
+{mutate_core._mutate_operations_hints()}
+"""
+
+
+remove.__doc__ = _remove_tool_description()
+mcp.add_tool(
+    Tool.from_function(
+        remove,
+        annotations=ToolAnnotations(destructiveHint=True),
+    )
+)

--- a/ads_mcp/tools/update.py
+++ b/ads_mcp/tools/update.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for exposing Google Ads mutate update operations to the MCP server."""
+
+from typing import Any, Dict, List
+
+from ads_mcp.coordinator import mcp
+from ads_mcp.tools import mutate_core
+from fastmcp.tools import Tool
+
+
+def update(
+    customer_id: str,
+    operations: List[Dict[str, Any]],
+    validate_only: bool = False,
+    partial_failure: bool = True,
+) -> Dict[str, Any]:
+    """Updates Google Ads resources using MutateOperation update clauses.
+
+    Each operation must use a nested *Operation message with update and
+    updateMask fields, such as campaignOperation.update.
+
+    Args:
+        customer_id: The Google Ads customer ID.
+        operations: A list of MutateOperation objects in API JSON form.
+        validate_only: If True, validates the request without applying changes.
+        partial_failure: If True, allows successful operations when some fail.
+
+    Returns:
+        A dict of mutate results from GoogleAdsService.mutate.
+
+    Raises:
+        ToolError: If the request is invalid or the API returns an error.
+    """
+    return mutate_core.execute_mutate(
+        customer_id=customer_id,
+        operations=operations,
+        validate_only=validate_only,
+        partial_failure=partial_failure,
+    )
+
+
+def _update_tool_description() -> str:
+    """Returns the description for the `update` tool."""
+    return f"""
+{update.__doc__}
+{mutate_core._mutate_operations_hints()}
+"""
+
+
+update.__doc__ = _update_tool_description()
+mcp.add_tool(Tool.from_function(update))

--- a/ads_mcp/tools/write_registration.py
+++ b/ads_mcp/tools/write_registration.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registers opt-in write tools when enabled via environment variables."""
+
+import ads_mcp.feature_flags as feature_flags
+import ads_mcp.utils as utils
+
+
+def register_write_tools() -> None:
+    """Registers write MCP tools when enabled by environment variables.
+
+    Imports create and update when GOOGLE_ADS_MCP_ENABLE_MUTATE is truthy.
+    Imports remove when GOOGLE_ADS_MCP_ENABLE_REMOVE is also truthy. Tools are
+    not listed in tools/list when their flags are unset.
+    """
+    if not feature_flags.is_mutate_enabled():
+        return
+
+    utils.logger.info(
+        "GOOGLE_ADS_MCP_ENABLE_MUTATE is set; registering create and update "
+        "tools."
+    )
+    from ads_mcp.tools import create, update  # noqa: F401
+
+    if feature_flags.is_remove_enabled():
+        utils.logger.info(
+            "GOOGLE_ADS_MCP_ENABLE_REMOVE is set; registering remove tool."
+        )
+        from ads_mcp.tools import remove  # noqa: F401

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 # OAuth scope for the Google Ads API. Google Ads does not publish a separate
-# read-only scope; access is restricted to read methods by the tools this
-# server exposes (see ads_mcp/tools/).
+# read-only scope. By default only read tools are registered; optional write
+# tools require GOOGLE_ADS_MCP_ENABLE_MUTATE (see ads_mcp/tools/write_registration.py).
 _ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
 
 

--- a/tests/feature_flags_test.py
+++ b/tests/feature_flags_test.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for environment-gated feature flags."""
+
+import os
+import unittest
+from unittest import mock
+
+from ads_mcp import feature_flags
+
+
+class TestFeatureFlags(unittest.TestCase):
+    """Test cases for environment-gated feature flags."""
+
+    def test_mutate_disabled_by_default(self):
+        """Tests that mutate is disabled when the env variable is unset."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("GOOGLE_ADS_MCP_ENABLE_MUTATE", None)
+            self.assertFalse(feature_flags.is_mutate_enabled())
+
+    def test_mutate_enabled(self):
+        """Tests that mutate is enabled for a truthy env value."""
+        with mock.patch.dict(
+            os.environ, {"GOOGLE_ADS_MCP_ENABLE_MUTATE": "1"}, clear=True
+        ):
+            self.assertTrue(feature_flags.is_mutate_enabled())
+
+    def test_remove_requires_mutate(self):
+        """Tests that remove stays disabled when mutate is not enabled."""
+        with mock.patch.dict(
+            os.environ, {"GOOGLE_ADS_MCP_ENABLE_REMOVE": "1"}, clear=True
+        ):
+            self.assertFalse(feature_flags.is_remove_enabled())
+
+    def test_remove_enabled_with_mutate(self):
+        """Tests that remove is enabled when both env flags are truthy."""
+        with mock.patch.dict(
+            os.environ,
+            {
+                "GOOGLE_ADS_MCP_ENABLE_MUTATE": "true",
+                "GOOGLE_ADS_MCP_ENABLE_REMOVE": "yes",
+            },
+            clear=True,
+        ):
+            self.assertTrue(feature_flags.is_remove_enabled())
+
+    def test_mutate_chunk_size_default(self):
+        """Tests the default mutate chunk size when the env variable is unset."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("GOOGLE_ADS_MCP_MUTATE_CHUNK_SIZE", None)
+            self.assertEqual(feature_flags.mutate_chunk_size(), 500)
+
+    def test_mutate_chunk_size_invalid(self):
+        """Tests that an invalid chunk size env value raises ValueError."""
+        with mock.patch.dict(
+            os.environ, {"GOOGLE_ADS_MCP_MUTATE_CHUNK_SIZE": "nope"}, clear=True
+        ):
+            with self.assertRaises(ValueError):
+                feature_flags.mutate_chunk_size()

--- a/tests/tools/mutate_core_test.py
+++ b/tests/tools/mutate_core_test.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the mutate_core module."""
+
+import os
+import unittest
+from unittest import mock
+
+from fastmcp.exceptions import ToolError
+from google.ads.googleads.client import GoogleAdsClient
+from google.ads.googleads.errors import GoogleAdsException
+
+from ads_mcp.tools import mutate_core
+
+
+def _test_client() -> GoogleAdsClient:
+    """Returns a GoogleAdsClient for unit tests without live credentials."""
+    with mock.patch("google.auth.default") as auth_default:
+        auth_default.return_value = (mock.MagicMock(), None)
+        return GoogleAdsClient(
+            credentials=mock.MagicMock(),
+            developer_token="test-token",
+            use_proto_plus=True,
+        )
+
+
+class TestMutateCore(unittest.TestCase):
+    """Test cases for the GoogleAdsService.mutate wrapper."""
+
+    def setUp(self):
+        """Sets the developer token required to construct the API client."""
+        os.environ["GOOGLE_ADS_DEVELOPER_TOKEN"] = "test-token"
+        self._client = _test_client()
+
+    @mock.patch("ads_mcp.tools.mutate_core.utils.get_googleads_type")
+    @mock.patch("ads_mcp.tools.mutate_core.utils.get_googleads_service")
+    def test_execute_mutate_single_chunk(self, mock_get_service, mock_get_type):
+        """Tests mutate with one chunk and normalized customer_id."""
+        mock_get_type.side_effect = self._client.get_type
+        mock_response = mock.MagicMock()
+        mock_response.mutate_operation_responses = [mock.MagicMock()]
+        mock_response.partial_failure_error = None
+        mock_get_service.return_value.mutate.return_value = mock_response
+
+        result = mutate_core.execute_mutate(
+            customer_id="123-456-7890",
+            operations=[
+                {
+                    "campaignOperation": {
+                        "update": {
+                            "resourceName": "customers/1/campaigns/2",
+                            "status": "PAUSED",
+                        },
+                        "updateMask": "status",
+                    }
+                }
+            ],
+            validate_only=True,
+        )
+
+        mock_get_service.return_value.mutate.assert_called_once()
+        call_request = mock_get_service.return_value.mutate.call_args.kwargs[
+            "request"
+        ]
+        self.assertEqual(call_request.customer_id, "1234567890")
+        self.assertTrue(call_request.validate_only)
+        self.assertEqual(len(call_request.mutate_operations), 1)
+        self.assertIn("mutate_operation_responses", result)
+
+    @mock.patch("ads_mcp.tools.mutate_core.feature_flags.mutate_chunk_size")
+    @mock.patch("ads_mcp.tools.mutate_core.utils.get_googleads_type")
+    @mock.patch("ads_mcp.tools.mutate_core.utils.get_googleads_service")
+    def test_execute_mutate_chunks(
+        self, mock_get_service, mock_get_type, mock_chunk_size
+    ):
+        """Tests that large operation lists are split across mutate calls."""
+        mock_chunk_size.return_value = 1
+        mock_get_type.side_effect = self._client.get_type
+        mock_response = mock.MagicMock()
+        mock_response.mutate_operation_responses = [mock.MagicMock()]
+        mock_response.partial_failure_error = None
+        mock_get_service.return_value.mutate.return_value = mock_response
+
+        mutate_core.execute_mutate(
+            customer_id="1",
+            operations=[
+                {
+                    "campaignOperation": {
+                        "update": {
+                            "resourceName": "customers/1/campaigns/1",
+                            "status": "PAUSED",
+                        },
+                        "updateMask": "status",
+                    }
+                },
+                {
+                    "campaignOperation": {
+                        "update": {
+                            "resourceName": "customers/1/campaigns/2",
+                            "status": "ENABLED",
+                        },
+                        "updateMask": "status",
+                    }
+                },
+            ],
+        )
+
+        self.assertEqual(mock_get_service.return_value.mutate.call_count, 2)
+
+    def test_execute_mutate_empty_operations(self):
+        """Tests that an empty operations list raises ToolError."""
+        with self.assertRaises(ToolError):
+            mutate_core.execute_mutate(customer_id="1", operations=[])
+
+    def test_parse_invalid_operation_type(self):
+        """Tests that non-dict operations raise ToolError during parsing."""
+        with self.assertRaises(ToolError):
+            mutate_core._parse_operations(["not-a-dict"])
+
+    @mock.patch("ads_mcp.tools.mutate_core.utils.get_googleads_type")
+    @mock.patch("ads_mcp.tools.mutate_core.utils.get_googleads_service")
+    def test_google_ads_exception(self, mock_get_service, mock_get_type):
+        """Tests that GoogleAdsException is converted to ToolError."""
+        mock_get_type.side_effect = self._client.get_type
+        ex = GoogleAdsException(
+            error=mock.MagicMock(),
+            call=mock.MagicMock(),
+            failure=mock.MagicMock(errors=[mock.MagicMock(message="boom")]),
+            request_id="req-1",
+        )
+        mock_get_service.return_value.mutate.side_effect = ex
+
+        with self.assertRaises(ToolError) as ctx:
+            mutate_core.execute_mutate(
+                customer_id="1",
+                operations=[
+                    {
+                        "campaignOperation": {
+                            "update": {
+                                "resourceName": "customers/1/campaigns/2",
+                                "status": "PAUSED",
+                            },
+                            "updateMask": "status",
+                        }
+                    }
+                ],
+            )
+        self.assertIn("req-1", str(ctx.exception))

--- a/tests/tools/write_registration_test.py
+++ b/tests/tools/write_registration_test.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for conditional write tool registration."""
+
+import os
+import subprocess
+import sys
+import unittest
+
+
+class TestWriteRegistration(unittest.TestCase):
+    """Test cases for conditional write tool registration."""
+
+    def _list_tool_names(self, env: dict) -> list[str]:
+        """Returns sorted MCP tool names for a subprocess with the given env."""
+        script = """
+import asyncio
+from ads_mcp.tools import search, core, get_resource_metadata  # noqa: F401
+from ads_mcp.tools import write_registration
+write_registration.register_write_tools()
+from ads_mcp.coordinator import mcp
+
+async def main():
+    tools = await mcp.list_tools()
+    print(",".join(sorted(t.name for t in tools)))
+
+asyncio.run(main())
+"""
+        merged = {**os.environ, **env}
+        merged.setdefault("GOOGLE_ADS_DEVELOPER_TOKEN", "test-token")
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=merged,
+            cwd=os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            ),
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=result.stderr or result.stdout,
+        )
+        return result.stdout.strip().split(",")
+
+    def test_default_tools_only(self):
+        """Tests that only read tools are registered by default."""
+        names = self._list_tool_names(
+            {
+                "GOOGLE_ADS_MCP_ENABLE_MUTATE": "",
+                "GOOGLE_ADS_MCP_ENABLE_REMOVE": "",
+            }
+        )
+        self.assertEqual(
+            names,
+            [
+                "get_resource_metadata",
+                "list_accessible_customers",
+                "search",
+            ],
+        )
+
+    def test_mutate_tools_registered(self):
+        """Tests that create and update are registered when mutate is enabled."""
+        names = self._list_tool_names({"GOOGLE_ADS_MCP_ENABLE_MUTATE": "1"})
+        self.assertIn("create", names)
+        self.assertIn("update", names)
+        self.assertNotIn("remove", names)
+
+    def test_remove_tool_registered(self):
+        """Tests that remove is registered when remove env is enabled."""
+        names = self._list_tool_names(
+            {
+                "GOOGLE_ADS_MCP_ENABLE_MUTATE": "1",
+                "GOOGLE_ADS_MCP_ENABLE_REMOVE": "1",
+            }
+        )
+        self.assertIn("remove", names)


### PR DESCRIPTION
## Summary

- Adds **opt-in** write MCP tools `create`, `update`, and `remove` behind environment variables; default `tools/list` is unchanged (read-only tools only).
- Implements shared `GoogleAdsService.mutate` execution with server-side chunking, `validate_only`, `partial_failure`, and REST-style `MutateOperation` JSON (camelCase).
- Registers write tools in `run_server()` when `GOOGLE_ADS_MCP_ENABLE_MUTATE=1`; `remove` additionally requires `GOOGLE_ADS_MCP_ENABLE_REMOVE=1`.
- Documents configuration and safety notes in README.

Closes #84 (proposal discussion).

## Design notes

- Three task-level tools (`create` / `update` / `remove`) share `mutate_core.execute_mutate`; no separate MutateJob/BatchJob MCP tools in this PR.
- `remove` uses MCP `destructiveHint`.
- Optional `GOOGLE_ADS_MCP_MUTATE_CHUNK_SIZE` (default 500).

## Test plan

- [x] `python -m unittest discover -s tests -p '*_test.py'` (36 tests)
- [ ] Maintainer review: env-gated registration acceptable for security model
- [ ] Manual test on a **test** Google Ads account with `validate_only=true`, then a small real update
- [ ] Confirm smoke/golden `tools/list` unchanged without env flags