### PR TITLE
Prevent OAuth credentials from being logged

### DIFF
--- a/ads_mcp/server.py
+++ b/ads_mcp/server.py
@@ -38,7 +38,12 @@ def run_server() -> None:
     port = int(os.environ.get("PORT", "8080"))
 
     if _CLIENT_ID and _CLIENT_SECRET:
-        mcp.run(transport="streamable-http", port=port, host="0.0.0.0")
+        mcp.run(
+            transport="streamable-http",
+            port=port,
+            host="0.0.0.0",
+            uvicorn_config={"access_log": False},
+        )
     else:
         mcp.run()
 

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -40,6 +40,7 @@ _GAQL_FILENAME = "gaql_resources.txt"
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 # OAuth scope for the Google Ads API. Google Ads does not publish a separate
 # read-only scope; access is restricted to read methods by the tools this


### PR DESCRIPTION
## Summary
Prevent OAuth credentials and callback values from being written to logs.

## Issue
The server currently has two sensitive logging paths:

- HTTPX INFO logs can include access tokens in token-validation request URLs.
- Uvicorn access logs include the full OAuth callback URL, including `code` and `state`.

Authorization codes are short-lived and single-use, but must not be exposed through container or centralized logs. Access tokens are bearer credentials and must never be logged.

## Changes
- Set the `httpx` logger to `WARNING` to suppress request URLs.
- Disable Uvicorn access logging for the streamable HTTP server.

The OAuth flow, scopes, token handling, and callback behavior are unchanged.

## Validation
- Python compilation passed.
- `git diff --check` passed.
- Both changes were validated against the pinned upstream source.