### PR TITLE
feat: add paused campaign and experiment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ to provide several
 - `get_resource_metadata`: Retrieves metadata about a Google Ads API resource type, for example "campaign". This is useful to understand the structure of the data and what fields are available for querying.
 - `list_accessible_customers`: Returns ids of customers directly accessible
   by the user authenticating the call.
+- `create_search_campaign_draft`: Creates a complete Search campaign, but keeps
+  its campaign, ad group, and ad paused. It is intended for reviewed draft setup,
+  not ad serving.
+- `create_search_experiment_draft`: Creates an unscheduled Search control and
+  treatment experiment from an existing campaign.
+- `schedule_experiment` and `end_experiment`: Lifecycle actions that require
+  `confirm: true`. Scheduling can begin spend and must only be called after the
+  user has explicitly approved the experiment.
 
 ### Configuring and Namespacing Tools
 
@@ -45,6 +53,11 @@ namespaces:
     prefix: "metadata"
     enabled_tools:
       - get_resource_metadata: true
+
+  # Campaign and experiment writes are separate namespaces so an operator can
+  # turn them off independently of read-only reporting.
+  campaigns: true
+  experiments: true
 ```
 
 

--- a/ads_mcp/config.py
+++ b/ads_mcp/config.py
@@ -28,7 +28,7 @@ DEFAULT_CONFIG_FILE = "tools_config.yaml"
 CONFIG_PATH_ENV_VAR = "GOOGLE_ADS_MCP_TOOLS_CONFIG"
 
 # Default categories that are supported by the server
-ALL_CATEGORIES = ["customers", "search", "metadata"]
+ALL_CATEGORIES = ["customers", "search", "metadata", "campaigns", "experiments"]
 
 
 class ToolsConfig:

--- a/ads_mcp/tools/campaigns.py
+++ b/ads_mcp/tools/campaigns.py
@@ -1,0 +1,171 @@
+# Copyright 2026 ReBattery.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Write tools for creating safely paused Google Ads campaign drafts."""
+
+from typing import Any
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+import ads_mcp.utils as utils
+
+
+campaigns_mcp = FastMCP("campaigns")
+
+
+def _customer_id(value: str) -> str:
+    normalized = value.replace("-", "").strip()
+    if not normalized.isdigit():
+        raise ValueError("customer_id must contain digits only.")
+    return normalized
+
+
+def _resource_name(response: Any, kind: str) -> str:
+    results = getattr(response, "results", None) or []
+    if not results or not getattr(results[0], "resource_name", None):
+        raise RuntimeError(f"Google Ads did not return a {kind} resource name.")
+    return results[0].resource_name
+
+
+@campaigns_mcp.tool(
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+)
+def create_search_campaign_draft(
+    customer_id: str,
+    name: str,
+    final_url: str,
+    headlines: list[str],
+    descriptions: list[str],
+    keywords: list[str],
+    daily_budget_micros: int,
+    geo_target_constant_ids: list[str] | None = None,
+    ad_group_name: str | None = None,
+) -> dict[str, Any]:
+    """Create a complete Search campaign in PAUSED status.
+
+    This creates a budget, campaign, ad group, responsive search ad, broad-match
+    keywords, and optional geo targets. It never enables the campaign or starts
+    serving ads. Review the returned resource names before a separate activation
+    action is introduced.
+    """
+    customer_id = _customer_id(customer_id)
+    if not name.strip() or not final_url.strip():
+        raise ValueError("name and final_url are required.")
+    if daily_budget_micros <= 0:
+        raise ValueError("daily_budget_micros must be positive.")
+    if not 3 <= len(headlines) <= 15:
+        raise ValueError("Responsive Search Ads require 3 to 15 headlines.")
+    if not 2 <= len(descriptions) <= 4:
+        raise ValueError("Responsive Search Ads require 2 to 4 descriptions.")
+    if not keywords:
+        raise ValueError("At least one keyword is required.")
+
+    client = utils.get_googleads_client()
+
+    budget_operation = client.get_type("CampaignBudgetOperation")
+    budget = budget_operation.create
+    budget.name = f"{name.strip()} budget"
+    budget.amount_micros = daily_budget_micros
+    budget.delivery_method = "STANDARD"
+    budget.explicitly_shared = False
+    budget_service = client.get_service("CampaignBudgetService")
+    budget_name = _resource_name(
+        budget_service.mutate_campaign_budgets(
+            customer_id=customer_id, operations=[budget_operation]
+        ),
+        "campaign budget",
+    )
+
+    campaign_operation = client.get_type("CampaignOperation")
+    campaign = campaign_operation.create
+    campaign.name = name.strip()
+    campaign.status = "PAUSED"
+    campaign.advertising_channel_type = "SEARCH"
+    campaign.campaign_budget = budget_name
+    campaign.manual_cpc.enhanced_cpc_enabled = False
+    campaign_service = client.get_service("CampaignService")
+    campaign_name = _resource_name(
+        campaign_service.mutate_campaigns(
+            customer_id=customer_id, operations=[campaign_operation]
+        ),
+        "campaign",
+    )
+
+    group_operation = client.get_type("AdGroupOperation")
+    group = group_operation.create
+    group.name = ad_group_name.strip() if ad_group_name else f"{name.strip()} ad group"
+    group.campaign = campaign_name
+    group.status = "PAUSED"
+    group.type_ = "SEARCH_STANDARD"
+    ad_group_service = client.get_service("AdGroupService")
+    group_name = _resource_name(
+        ad_group_service.mutate_ad_groups(
+            customer_id=customer_id, operations=[group_operation]
+        ),
+        "ad group",
+    )
+
+    ad_operation = client.get_type("AdGroupAdOperation")
+    ad_group_ad = ad_operation.create
+    ad_group_ad.ad_group = group_name
+    ad_group_ad.status = "PAUSED"
+    ad_group_ad.ad.final_urls.append(final_url.strip())
+    for headline in headlines:
+        ad_group_ad.ad.responsive_search_ad.headlines.append(
+            client.get_type("AdTextAsset")(text=headline.strip())
+        )
+    for description in descriptions:
+        ad_group_ad.ad.responsive_search_ad.descriptions.append(
+            client.get_type("AdTextAsset")(text=description.strip())
+        )
+    ad_group_ad_service = client.get_service("AdGroupAdService")
+    ad_name = _resource_name(
+        ad_group_ad_service.mutate_ad_group_ads(
+            customer_id=customer_id, operations=[ad_operation]
+        ),
+        "ad",
+    )
+
+    criterion_operations = []
+    for keyword in keywords:
+        if not keyword.strip():
+            continue
+        operation = client.get_type("AdGroupCriterionOperation")
+        criterion = operation.create
+        criterion.ad_group = group_name
+        criterion.status = "PAUSED"
+        criterion.keyword.text = keyword.strip()
+        criterion.keyword.match_type = "BROAD"
+        criterion_operations.append(operation)
+    if not criterion_operations:
+        raise ValueError("keywords must include at least one non-empty value.")
+    criterion_service = client.get_service("AdGroupCriterionService")
+    criterion_response = criterion_service.mutate_ad_group_criteria(
+        customer_id=customer_id, operations=criterion_operations
+    )
+
+    location_count = 0
+    if geo_target_constant_ids:
+        location_operations = []
+        for geo_id in geo_target_constant_ids:
+            operation = client.get_type("CampaignCriterionOperation")
+            criterion = operation.create
+            criterion.campaign = campaign_name
+            criterion.location.geo_target_constant = f"geoTargetConstants/{geo_id}"
+            location_operations.append(operation)
+        if location_operations:
+            client.get_service("CampaignCriterionService").mutate_campaign_criteria(
+                customer_id=customer_id, operations=location_operations
+            )
+            location_count = len(location_operations)
+
+    return {
+        "status": "PAUSED_DRAFT",
+        "campaign": campaign_name,
+        "budget": budget_name,
+        "ad_group": group_name,
+        "ad": ad_name,
+        "keyword_count": len(criterion_response.results),
+        "geo_target_count": location_count,
+    }

--- a/ads_mcp/tools/experiments.py
+++ b/ads_mcp/tools/experiments.py
@@ -1,0 +1,100 @@
+# Copyright 2026 ReBattery.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tools for staged Google Ads campaign experiments."""
+
+from typing import Any
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+import ads_mcp.utils as utils
+from ads_mcp.tools.campaigns import _customer_id, _resource_name
+
+
+experiments_mcp = FastMCP("experiments")
+
+
+def _confirmed(confirm: bool) -> None:
+    if not confirm:
+        raise ValueError("Set confirm=true to perform this spend-affecting experiment action.")
+
+
+@experiments_mcp.tool(
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+)
+def create_search_experiment_draft(
+    customer_id: str, base_campaign_id: str, name: str
+) -> dict[str, str]:
+    """Create a SEARCH_CUSTOM experiment and its control/treatment arms.
+
+    The experiment is left unscheduled. Google creates the treatment campaign
+    from the control campaign; use the returned resource name for an explicit,
+    confirmed schedule action after reviewing the treatment configuration.
+    """
+    customer_id = _customer_id(customer_id)
+    if not base_campaign_id.isdigit() or not name.strip():
+        raise ValueError("base_campaign_id and name are required.")
+    client = utils.get_googleads_client()
+    experiment_operation = client.get_type("ExperimentOperation")
+    experiment = experiment_operation.create
+    experiment.name = name.strip()
+    experiment.type_ = "SEARCH_CUSTOM"
+    experiment_name = _resource_name(
+        client.get_service("ExperimentService").mutate_experiments(
+            customer_id=customer_id, operations=[experiment_operation]
+        ),
+        "experiment",
+    )
+
+    campaign_name = client.get_service("CampaignService").campaign_path(
+        customer_id, base_campaign_id
+    )
+    control_operation = client.get_type("ExperimentArmOperation")
+    control = control_operation.create
+    control.name = f"{name.strip()} control"
+    control.experiment = experiment_name
+    control.control = True
+    control.campaigns.append(campaign_name)
+
+    treatment_operation = client.get_type("ExperimentArmOperation")
+    treatment = treatment_operation.create
+    treatment.name = f"{name.strip()} treatment"
+    treatment.experiment = experiment_name
+    treatment.control = False
+
+    arm_response = client.get_service("ExperimentArmService").mutate_experiment_arms(
+        customer_id=customer_id, operations=[control_operation, treatment_operation]
+    )
+    return {
+        "status": "DRAFT_NOT_SCHEDULED",
+        "experiment": experiment_name,
+        "control_arm": arm_response.results[0].resource_name,
+        "treatment_arm": arm_response.results[1].resource_name,
+    }
+
+
+@experiments_mcp.tool(
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+)
+def schedule_experiment(customer_id: str, experiment_resource_name: str, confirm: bool = False) -> dict[str, str]:
+    """Schedule an experiment after explicit confirmation. This can begin spending."""
+    _confirmed(confirm)
+    client = utils.get_googleads_client()
+    client.get_service("ExperimentService").schedule_experiment(
+        resource_name=experiment_resource_name
+    )
+    return {"status": "SCHEDULED", "experiment": experiment_resource_name, "customer_id": _customer_id(customer_id)}
+
+
+@experiments_mcp.tool(
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+)
+def end_experiment(customer_id: str, experiment_resource_name: str, confirm: bool = False) -> dict[str, str]:
+    """End an experiment after explicit confirmation."""
+    _confirmed(confirm)
+    client = utils.get_googleads_client()
+    client.get_service("ExperimentService").end_experiment(
+        resource_name=experiment_resource_name
+    )
+    return {"status": "ENDED", "experiment": experiment_resource_name, "customer_id": _customer_id(customer_id)}

--- a/ads_mcp/tools_config.yaml
+++ b/ads_mcp/tools_config.yaml
@@ -7,3 +7,5 @@ namespaces:
   customers: true
   search: true
   metadata: true
+  campaigns: true
+  experiments: true

--- a/tests/tools/campaigns_test.py
+++ b/tests/tools/campaigns_test.py
@@ -1,0 +1,46 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ads_mcp.tools import campaigns
+
+
+def mutation_response(name):
+    return SimpleNamespace(results=[SimpleNamespace(resource_name=name)])
+
+
+class TestCampaignDraft(unittest.TestCase):
+    @patch("ads_mcp.utils.get_googleads_client")
+    def test_creates_only_paused_resources(self, get_client):
+        client = MagicMock()
+        get_client.return_value = client
+        services = {
+            "CampaignBudgetService": MagicMock(), "CampaignService": MagicMock(),
+            "AdGroupService": MagicMock(), "AdGroupAdService": MagicMock(),
+            "AdGroupCriterionService": MagicMock(), "CampaignCriterionService": MagicMock(),
+        }
+        client.get_service.side_effect = lambda name: services[name]
+        services["CampaignBudgetService"].mutate_campaign_budgets.return_value = mutation_response("customers/1/campaignBudgets/1")
+        services["CampaignService"].mutate_campaigns.return_value = mutation_response("customers/1/campaigns/1")
+        services["AdGroupService"].mutate_ad_groups.return_value = mutation_response("customers/1/adGroups/1")
+        services["AdGroupAdService"].mutate_ad_group_ads.return_value = mutation_response("customers/1/adGroupAds/1")
+        services["AdGroupCriterionService"].mutate_ad_group_criteria.return_value = SimpleNamespace(results=[MagicMock(), MagicMock()])
+
+        result = campaigns.create_search_campaign_draft(
+            "123-456-7890", "Draft", "https://example.com", ["one", "two", "three"],
+            ["one", "two"], ["battery recycling", "battery collection"], 1_000_000, ["2826"],
+        )
+
+        self.assertEqual(result["status"], "PAUSED_DRAFT")
+        campaign = client.get_type("CampaignOperation").create
+        self.assertEqual(campaign.status, "PAUSED")
+        group = client.get_type("AdGroupOperation").create
+        self.assertEqual(group.status, "PAUSED")
+        ad = client.get_type("AdGroupAdOperation").create
+        self.assertEqual(ad.status, "PAUSED")
+
+    def test_rejects_invalid_rsa_before_api_calls(self):
+        with self.assertRaisesRegex(ValueError, "3 to 15 headlines"):
+            campaigns.create_search_campaign_draft(
+                "123", "Draft", "https://example.com", ["one"], ["one", "two"], ["keyword"], 1
+            )

--- a/tests/tools/experiments_test.py
+++ b/tests/tools/experiments_test.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ads_mcp.tools import experiments
+
+
+class TestExperimentLifecycle(unittest.TestCase):
+    def test_schedule_requires_explicit_confirmation(self):
+        with self.assertRaisesRegex(ValueError, "confirm=true"):
+            experiments.schedule_experiment("123", "customers/123/experiments/1")
+
+    @patch("ads_mcp.utils.get_googleads_client")
+    def test_schedule_calls_google_only_after_confirmation(self, get_client):
+        client = MagicMock()
+        service = MagicMock()
+        client.get_service.return_value = service
+        get_client.return_value = client
+        result = experiments.schedule_experiment("123", "customers/123/experiments/1", confirm=True)
+        service.schedule_experiment.assert_called_once_with(resource_name="customers/123/experiments/1")
+        self.assertEqual(result["status"], "SCHEDULED")


### PR DESCRIPTION
## Summary
- add a paused Search-campaign draft tool with budget, ad group, RSA, keywords, and geo targets
- add unscheduled Search experiment creation plus explicitly confirmed scheduling/end actions
- expose write namespaces through the existing tool config and document their safety boundary

## Verification
- `python -m unittest discover -s tests -p '*test.py'` (41 tests)
- source MCP tool discovery verifies all four new tools

## Notes
- This PR does not register the server with live Hermes or configure credentials.
- Live Google Ads execution remains pending the existing service-account credential path and developer token.