### PR TITLE
feat: log tool calls to mcp_usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+.dockerignore
+.env*
+.venv/
+__pycache__/
+*.pyc
+*.egg-info/
+build/
+.pytest_cache/
+.claude/
+.idea
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY . .
 # Install the project and its dependencies
 # We use --system to install into the system Python environment in the container
 RUN uv pip install --system .
+RUN uv pip install "fastmcp==3.4.2" --system
 
 # Expose port 8080 (default for Cloud Run)
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY . .
 # Install the project and its dependencies
 # We use --system to install into the system Python environment in the container
 RUN uv pip install --system .
-RUN uv pip install "mcp<1.23.0" --system
 
 # Expose port 8080 (default for Cloud Run)
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY . .
 # Install the project and its dependencies
 # We use --system to install into the system Python environment in the container
 RUN uv pip install --system .
+RUN uv pip install "mcp<1.23.0" --system
 
 # Expose port 8080 (default for Cloud Run)
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ to provide several
 - `list_accessible_customers`: Returns ids of customers directly accessible
   by the user authenticating the call.
 
+#### Keyword Planner tools
+
+Read-only Keyword Planner tools (namespace `keyword_planner`) that generate or list data without persisting anything in the account.
+
+- `generate_keyword_ideas`: Generates keyword ideas with historical metrics (search volume, competition, CPC bid ranges) from seed keywords and/or a landing page URL.
+- `generate_keyword_historical_metrics`: Returns historical metrics for a specific list of keywords.
+- `list_plannable_locations`: Lists locations that can be used for reach forecasting.
+- `list_plannable_products`: Lists ad products available for reach forecasting in a given location.
+- `list_audience_insights_attributes`: Searches for audience attributes (interests, demographics, entities, locations) by free text.
+- `list_insights_eligible_dates`: Returns the date ranges for which audience insights data is available.
+
 ### Configuring and Namespacing Tools
 
 The Google Ads MCP server uses the `tools_config.yaml` to let you selectively enable or disable individual tools or tool categories (namespaces) and customize their namespace prefixes.

--- a/ads_mcp/config.py
+++ b/ads_mcp/config.py
@@ -28,7 +28,7 @@ DEFAULT_CONFIG_FILE = "tools_config.yaml"
 CONFIG_PATH_ENV_VAR = "GOOGLE_ADS_MCP_TOOLS_CONFIG"
 
 # Default categories that are supported by the server
-ALL_CATEGORIES = ["customers", "search", "metadata"]
+ALL_CATEGORIES = ["customers", "search", "metadata", "keyword_planner"]
 
 
 class ToolsConfig:

--- a/ads_mcp/coordinator.py
+++ b/ads_mcp/coordinator.py
@@ -23,6 +23,8 @@ import os
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.google import GoogleProvider
 
+from ads_mcp.usage_log import UsageLogMiddleware
+
 _CLIENT_ID = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_ID")
 _CLIENT_SECRET = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET")
 _BASE_URL = os.environ.get("GOOGLE_ADS_MCP_BASE_URL", "http://localhost:8080")
@@ -40,6 +42,7 @@ if _CLIENT_ID and _CLIENT_SECRET:
         ],
     )
     mcp = FastMCP("Google Ads Server", auth=auth)
+    mcp.add_middleware(UsageLogMiddleware.from_env(server="google-ads"))
 else:
     mcp = FastMCP("Google Ads Server")
 

--- a/ads_mcp/server.py
+++ b/ads_mcp/server.py
@@ -29,10 +29,16 @@ from ads_mcp.resources import (
 )  # noqa: F401
 
 
+import logging
 import os
+
+_LOGGERS_THAT_PRINT_ACCESS_TOKENS = ("httpx", "httpx2")
 
 
 def run_server() -> None:
+    for logger_name in _LOGGERS_THAT_PRINT_ACCESS_TOKENS:
+        logging.getLogger(logger_name).setLevel(logging.WARNING)
+
     _CLIENT_ID = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_ID")
     _CLIENT_SECRET = os.environ.get("GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET")
     port = int(os.environ.get("PORT", "8080"))

--- a/ads_mcp/tools/keyword_planner.py
+++ b/ads_mcp/tools/keyword_planner.py
@@ -241,6 +241,7 @@ def list_audience_insights_attributes(
     customer_id: str,
     dimensions: List[str],
     query_text: str,
+    customer_insights_group: str = "google-ads-mcp",
 ) -> List[Dict[str, Any]]:
     """Searches for audience attributes (interests, demographics, entities, locations) by free text.
 
@@ -256,11 +257,14 @@ def list_audience_insights_attributes(
         customer_id: The id of the customer (digits only, no punctuation).
         dimensions: Which attribute dimensions to search within.
         query_text: The free-text term to search for (e.g. 'running shoes').
+        customer_insights_group: A label used to group insights requests. This is
+            a required API field; a default is provided.
     """
     service = utils.get_googleads_service("AudienceInsightsService")
     request = utils.get_googleads_type("ListAudienceInsightsAttributesRequest")
 
     request.customer_id = customer_id
+    request.customer_insights_group = customer_insights_group
     request.dimensions = dimensions
     request.query_text = query_text
 

--- a/ads_mcp/tools/keyword_planner.py
+++ b/ads_mcp/tools/keyword_planner.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read-only Keyword Planner tools (Phase 1).
+
+Exposes the Google Ads Keyword Planner "generate/list" methods that do not
+persist anything in the account, keeping this server read-only:
+
+  * KeywordPlanIdeaService.GenerateKeywordIdeas
+  * KeywordPlanIdeaService.GenerateKeywordHistoricalMetrics
+  * ReachPlanService.ListPlannableLocations
+  * ReachPlanService.ListPlannableProducts
+  * AudienceInsightsService.ListAudienceInsightsAttributes
+  * AudienceInsightsService.ListInsightsEligibleDates
+"""
+
+import functools
+from typing import Any, Callable, Dict, List
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from mcp.types import ToolAnnotations
+from google.ads.googleads.errors import GoogleAdsException
+
+import ads_mcp.utils as utils
+
+keyword_planner_mcp = FastMCP("keyword_planner")
+
+
+def _translate_google_ads_errors(func: Callable) -> Callable:
+    """Wraps a tool so GoogleAdsException surfaces as a readable ToolError.
+
+    Mirrors the error handling used by the `search` tool so failures reach the
+    model as actionable messages instead of raw stack traces.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return func(*args, **kwargs)
+        except GoogleAdsException as ex:
+            error_msgs = [
+                f"Google Ads API Error: {error.message}"
+                for error in ex.failure.errors
+            ]
+            raise ToolError(
+                f"Request ID: {ex.request_id}\n" + "\n".join(error_msgs)
+            )
+
+    return wrapper
+
+
+def _to_geo_resource(value: str) -> str:
+    """Normalizes a geo target into a resource name.
+
+    Accepts either a bare criterion id ('2276') or a full resource name
+    ('geoTargetConstants/2276') and always returns the resource name form.
+    """
+    trimmed = value.strip()
+    return f"geoTargetConstants/{trimmed}" if trimmed.isdigit() else trimmed
+
+
+def _to_language_resource(value: str) -> str:
+    """Normalizes a language into a resource name.
+
+    Accepts either a bare criterion id ('1001') or a full resource name
+    ('languageConstants/1001') and always returns the resource name form.
+    """
+    trimmed = value.strip()
+    return f"languageConstants/{trimmed}" if trimmed.isdigit() else trimmed
+
+
+def _format_results(results: Any) -> List[Dict[str, Any]]:
+    """Converts an iterable of proto messages into a list of plain dicts."""
+    return [utils.format_output_value(result) for result in results]
+
+
+@keyword_planner_mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+@_translate_google_ads_errors
+def generate_keyword_ideas(
+    customer_id: str,
+    geo_target_constants: List[str],
+    language: str,
+    keywords: List[str] = [],
+    page_url: str | None = None,
+    keyword_plan_network: str = "GOOGLE_SEARCH",
+    include_adult_keywords: bool = False,
+    limit: int | None = None,
+) -> List[Dict[str, Any]]:
+    """Generates keyword ideas with historical metrics (search volume, competition, CPC bid ranges).
+
+    Provide at least one seed: `keywords`, a `page_url`, or both.
+
+    ### customer_id
+        A string of digits without punctuation (e.g. '1234567890', not '123-456-7890').
+
+    ### geo_target_constants / language
+        Pass Google Ads criterion ids ('2276', '1001') or full resource names
+        ('geoTargetConstants/2276', 'languageConstants/1001'). Both forms are accepted.
+        To look up ids, use the `search` tool on the `geo_target_constant` and
+        `language_constant` resources.
+
+    ### keyword_plan_network
+        One of 'GOOGLE_SEARCH' or 'GOOGLE_SEARCH_AND_PARTNERS'.
+
+    Args:
+        customer_id: The id of the customer.
+        geo_target_constants: One or more geo targets to scope metrics to.
+        language: The language to scope metrics to.
+        keywords: Seed keywords to expand from.
+        page_url: A seed landing page URL to derive ideas from.
+        keyword_plan_network: Which network the metrics apply to.
+        include_adult_keywords: Whether to include adult keywords in the results.
+        limit: Maximum number of ideas to return (client-side cap).
+    """
+    if not keywords and not page_url:
+        raise ToolError(
+            "Provide at least one seed: 'keywords', 'page_url', or both."
+        )
+
+    service = utils.get_googleads_service("KeywordPlanIdeaService")
+    request = utils.get_googleads_type("GenerateKeywordIdeasRequest")
+
+    request.customer_id = customer_id
+    request.language = _to_language_resource(language)
+    request.geo_target_constants.extend(
+        _to_geo_resource(geo) for geo in geo_target_constants
+    )
+    request.keyword_plan_network = keyword_plan_network
+    request.include_adult_keywords = include_adult_keywords
+
+    if keywords and page_url:
+        request.keyword_and_url_seed.url = page_url
+        request.keyword_and_url_seed.keywords.extend(keywords)
+    elif keywords:
+        request.keyword_seed.keywords.extend(keywords)
+    else:
+        request.url_seed.url = page_url
+
+    response = service.generate_keyword_ideas(request=request)
+
+    ideas: List[Dict[str, Any]] = []
+    for index, result in enumerate(response):
+        if limit is not None and index >= limit:
+            break
+        ideas.append(utils.format_output_value(result))
+    return ideas
+
+
+@keyword_planner_mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+@_translate_google_ads_errors
+def generate_keyword_historical_metrics(
+    customer_id: str,
+    keywords: List[str],
+    geo_target_constants: List[str],
+    language: str,
+    keyword_plan_network: str = "GOOGLE_SEARCH",
+    include_adult_keywords: bool = False,
+) -> List[Dict[str, Any]]:
+    """Returns historical metrics (search volume, competition, CPC bid ranges) for specific keywords.
+
+    Unlike `generate_keyword_ideas`, this does not expand seeds; it reports
+    metrics for exactly the keywords you pass.
+
+    See `generate_keyword_ideas` for the accepted `customer_id`,
+    `geo_target_constants`, `language`, and `keyword_plan_network` formats.
+
+    Args:
+        customer_id: The id of the customer.
+        keywords: The exact keywords to fetch metrics for.
+        geo_target_constants: One or more geo targets to scope metrics to.
+        language: The language to scope metrics to.
+        keyword_plan_network: Which network the metrics apply to.
+        include_adult_keywords: Whether to include adult keywords in the results.
+    """
+    service = utils.get_googleads_service("KeywordPlanIdeaService")
+    request = utils.get_googleads_type(
+        "GenerateKeywordHistoricalMetricsRequest"
+    )
+
+    request.customer_id = customer_id
+    request.keywords.extend(keywords)
+    request.language = _to_language_resource(language)
+    request.geo_target_constants.extend(
+        _to_geo_resource(geo) for geo in geo_target_constants
+    )
+    request.keyword_plan_network = keyword_plan_network
+    request.include_adult_keywords = include_adult_keywords
+
+    response = service.generate_keyword_historical_metrics(request=request)
+    return _format_results(response.results)
+
+
+@keyword_planner_mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+@_translate_google_ads_errors
+def list_plannable_locations() -> List[Dict[str, Any]]:
+    """Lists locations that can be used for reach forecasting (ReachPlanService).
+
+    Returns location ids and names to use as `plannable_location_id` for
+    `list_plannable_products`.
+    """
+    service = utils.get_googleads_service("ReachPlanService")
+    request = utils.get_googleads_type("ListPlannableLocationsRequest")
+
+    response = service.list_plannable_locations(request=request)
+    return _format_results(response.plannable_locations)
+
+
+@keyword_planner_mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+@_translate_google_ads_errors
+def list_plannable_products(
+    plannable_location_id: str,
+) -> List[Dict[str, Any]]:
+    """Lists ad products available for reach forecasting in a given location.
+
+    Args:
+        plannable_location_id: A location id from `list_plannable_locations`.
+    """
+    service = utils.get_googleads_service("ReachPlanService")
+    request = utils.get_googleads_type("ListPlannableProductsRequest")
+    request.plannable_location_id = plannable_location_id
+
+    response = service.list_plannable_products(request=request)
+    return _format_results(response.product_metadata)
+
+
+@keyword_planner_mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+@_translate_google_ads_errors
+def list_audience_insights_attributes(
+    customer_id: str,
+    dimensions: List[str],
+    query_text: str,
+) -> List[Dict[str, Any]]:
+    """Searches for audience attributes (interests, demographics, entities, locations) by free text.
+
+    Use the returned attributes as building blocks for audience analysis.
+
+    ### dimensions
+        One or more of: 'KNOWLEDGE_GRAPH', 'GEO_TARGET_COUNTRY',
+        'SUB_COUNTRY_LOCATION', 'YOUTUBE_CHANNEL', 'AFFINITY_USER_INTEREST',
+        'IN_MARKET_USER_INTEREST', 'PARENTAL_STATUS', 'INCOME_RANGE',
+        'AGE_RANGE', 'GENDER', 'DEVICE'.
+
+    Args:
+        customer_id: The id of the customer (digits only, no punctuation).
+        dimensions: Which attribute dimensions to search within.
+        query_text: The free-text term to search for (e.g. 'running shoes').
+    """
+    service = utils.get_googleads_service("AudienceInsightsService")
+    request = utils.get_googleads_type("ListAudienceInsightsAttributesRequest")
+
+    request.customer_id = customer_id
+    request.dimensions = dimensions
+    request.query_text = query_text
+
+    response = service.list_audience_insights_attributes(request=request)
+    return _format_results(response.attributes)
+
+
+@keyword_planner_mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+@_translate_google_ads_errors
+def list_insights_eligible_dates() -> Dict[str, Any]:
+    """Returns the date ranges for which audience insights data is available.
+
+    Useful to pick a valid reporting period before requesting insights.
+    """
+    service = utils.get_googleads_service("AudienceInsightsService")
+    request = utils.get_googleads_type("ListInsightsEligibleDatesRequest")
+
+    response = service.list_insights_eligible_dates(request=request)
+    return utils.format_output_value(response)

--- a/ads_mcp/tools_config.yaml
+++ b/ads_mcp/tools_config.yaml
@@ -7,3 +7,4 @@ namespaces:
   customers: true
   search: true
   metadata: true
+  keyword_planner: true

--- a/ads_mcp/usage_log/__init__.py
+++ b/ads_mcp/usage_log/__init__.py
@@ -1,0 +1,3 @@
+from .middleware import UsageLogMiddleware
+
+__all__ = ["UsageLogMiddleware"]

--- a/ads_mcp/usage_log/arguments.py
+++ b/ads_mcp/usage_log/arguments.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
+ACCOUNT_ID_KEYS = ("customer_id", "merchant_id", "property_id")
+
+
+def read_account_id(arguments: dict[str, Any] | None) -> str | None:
+    for key in ACCOUNT_ID_KEYS:
+        value = (arguments or {}).get(key)
+        if value is not None:
+            return str(value)
+    return None

--- a/ads_mcp/usage_log/config.py
+++ b/ads_mcp/usage_log/config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+DSN_ENV_VAR = "MCP_USAGE_DSN"
+
+
+def read_dsn() -> str:
+    dsn = os.environ.get(DSN_ENV_VAR, "").strip()
+    if not dsn:
+        raise RuntimeError(
+            f"{DSN_ENV_VAR} is unset or empty — usage logging cannot start. "
+            f"Expected a Postgres DSN including sslmode=require."
+        )
+    return dsn

--- a/ads_mcp/usage_log/identity.py
+++ b/ads_mcp/usage_log/identity.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastmcp.server.dependencies import get_access_token
+
+
+@dataclass(frozen=True)
+class Identity:
+    sub: str
+    email: str | None
+
+
+def read_identity() -> Identity | None:
+    token = get_access_token()
+    claims = token.claims if token else {}
+    sub = claims.get("sub")
+    if not sub:
+        return None
+    email = claims.get("email")
+    return Identity(sub=str(sub), email=str(email) if email else None)

--- a/ads_mcp/usage_log/middleware.py
+++ b/ads_mcp/usage_log/middleware.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+
+from fastmcp.server.middleware import Middleware
+
+from .arguments import read_account_id
+from .config import read_dsn
+from .identity import read_identity
+from .sink import PostgresSink, Sink, ToolCall
+
+logger = logging.getLogger(__name__)
+
+
+class UsageLogMiddleware(Middleware):
+    def __init__(self, server: str, sink: Sink) -> None:
+        self._server = server
+        self._sink = sink
+
+    @classmethod
+    def from_env(cls, server: str) -> UsageLogMiddleware:
+        return cls(server=server, sink=PostgresSink(read_dsn()))
+
+    async def on_call_tool(self, context, call_next):
+        status = "error"
+        try:
+            result = await call_next(context)
+            status = "ok" if not result.is_error else "error"
+            return result
+        finally:
+            await self._record(context, status)
+
+    async def _record(self, context, status: str) -> None:
+        try:
+            identity = read_identity()
+            if identity is None:
+                logger.error(
+                    "usage log skipped for %r: access token carries no sub claim",
+                    context.message.name,
+                )
+                return
+            if identity.email is None:
+                logger.error("usage log has no email claim for sub %s", identity.sub)
+            await self._sink.write(
+                ToolCall(
+                    occurred_at=context.timestamp,
+                    server=self._server,
+                    tool=context.message.name,
+                    user_sub=identity.sub,
+                    user_email=identity.email,
+                    account_id=read_account_id(context.message.arguments),
+                    status=status,
+                )
+            )
+        except Exception:
+            logger.error("usage log write failed", exc_info=True)

--- a/ads_mcp/usage_log/sink.py
+++ b/ads_mcp/usage_log/sink.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from psycopg_pool import AsyncConnectionPool
+
+INSERT_SQL = """
+INSERT INTO tool_call
+  (occurred_at, server, tool, user_sub, user_email, account_id, status)
+VALUES (%s, %s, %s, %s, %s, %s, %s)
+"""
+
+WRITE_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    occurred_at: datetime
+    server: str
+    tool: str
+    user_sub: str
+    user_email: str | None
+    account_id: str | None
+    status: str
+
+
+class Sink(Protocol):
+    async def write(self, call: ToolCall) -> None: ...
+
+
+class PostgresSink:
+    def __init__(self, dsn: str, max_size: int = 3) -> None:
+        self._pool = AsyncConnectionPool(dsn, min_size=1, max_size=max_size, open=False)
+        self._opened = False
+        self._open_lock = asyncio.Lock()
+
+    async def write(self, call: ToolCall) -> None:
+        await asyncio.wait_for(self._write(call), timeout=WRITE_TIMEOUT_SECONDS)
+
+    async def _write(self, call: ToolCall) -> None:
+        await self._ensure_open()
+        async with self._pool.connection() as conn:
+            await conn.execute(
+                INSERT_SQL,
+                (
+                    call.occurred_at,
+                    call.server,
+                    call.tool,
+                    call.user_sub,
+                    call.user_email,
+                    call.account_id,
+                    call.status,
+                ),
+            )
+
+    async def _ensure_open(self) -> None:
+        if self._opened:
+            return
+        async with self._open_lock:
+            if not self._opened:
+                await self._pool.open()
+                self._opened = True
+
+    async def close(self) -> None:
+        if self._opened:
+            await self._pool.close()
+            self._opened = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ license = "Apache-2.0"
 dependencies = [
     "google-ads>=31.0.0",
     "mcp[cli]>=1.2.0",
-    "fastmcp>=3.2.0"
+    "fastmcp>=3.4.2",
+    "psycopg[binary,pool]>=3.2"
 ]
 
 description = "MCP Server for Google Ads, depends on Google Ads API."
@@ -33,3 +34,6 @@ issues = "https://github.com/googleads/google-ads-mcp/issues"
 [project.scripts]
 google-ads-mcp = "ads_mcp.server:run_server"
 google-ads-mcp-update-gaql = "ads_mcp.update_references:update_gaql_resource_file"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/tools/keyword_planner_test.py
+++ b/tests/tools/keyword_planner_test.py
@@ -1,0 +1,297 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the keyword_planner tools."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fastmcp.exceptions import ToolError
+
+from ads_mcp.tools import keyword_planner
+
+
+class TestNormalizationHelpers(unittest.TestCase):
+    """Tests for the geo/language resource-name normalization helpers."""
+
+    def test_geo_bare_id_is_wrapped(self):
+        self.assertEqual(
+            keyword_planner._to_geo_resource("2276"),
+            "geoTargetConstants/2276",
+        )
+
+    def test_geo_resource_name_is_passed_through(self):
+        self.assertEqual(
+            keyword_planner._to_geo_resource("geoTargetConstants/2276"),
+            "geoTargetConstants/2276",
+        )
+
+    def test_language_bare_id_is_wrapped(self):
+        self.assertEqual(
+            keyword_planner._to_language_resource("1001"),
+            "languageConstants/1001",
+        )
+
+    def test_language_resource_name_is_passed_through(self):
+        self.assertEqual(
+            keyword_planner._to_language_resource("languageConstants/1001"),
+            "languageConstants/1001",
+        )
+
+
+class TestGenerateKeywordIdeas(unittest.TestCase):
+    """Test cases for generate_keyword_ideas."""
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_value")
+    def test_keyword_seed_and_result_formatting(
+        self, mock_format, mock_get_service, mock_get_type
+    ):
+        request = MagicMock()
+        mock_get_type.return_value = request
+        service = MagicMock()
+        mock_get_service.return_value = service
+        service.generate_keyword_ideas.return_value = [
+            MagicMock(),
+            MagicMock(),
+        ]
+        mock_format.side_effect = [{"text": "a"}, {"text": "b"}]
+
+        results = keyword_planner.generate_keyword_ideas(
+            customer_id="1234567890",
+            geo_target_constants=["2276"],
+            language="1001",
+            keywords=["running shoes"],
+        )
+
+        mock_get_service.assert_called_once_with("KeywordPlanIdeaService")
+        self.assertEqual(request.customer_id, "1234567890")
+        self.assertEqual(request.language, "languageConstants/1001")
+        request.keyword_seed.keywords.extend.assert_called_once_with(
+            ["running shoes"]
+        )
+        self.assertEqual(results, [{"text": "a"}, {"text": "b"}])
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_value")
+    def test_keyword_and_url_seed(
+        self, mock_format, mock_get_service, mock_get_type
+    ):
+        request = MagicMock()
+        mock_get_type.return_value = request
+        mock_get_service.return_value.generate_keyword_ideas.return_value = []
+
+        keyword_planner.generate_keyword_ideas(
+            customer_id="1234567890",
+            geo_target_constants=["2276"],
+            language="1001",
+            keywords=["shoes"],
+            page_url="https://example.com",
+        )
+
+        self.assertEqual(
+            request.keyword_and_url_seed.url, "https://example.com"
+        )
+        request.keyword_and_url_seed.keywords.extend.assert_called_once_with(
+            ["shoes"]
+        )
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_value")
+    def test_limit_caps_results(
+        self, mock_format, mock_get_service, mock_get_type
+    ):
+        mock_get_type.return_value = MagicMock()
+        mock_get_service.return_value.generate_keyword_ideas.return_value = [
+            MagicMock() for _ in range(5)
+        ]
+        mock_format.side_effect = lambda r: {"idea": id(r)}
+
+        results = keyword_planner.generate_keyword_ideas(
+            customer_id="1234567890",
+            geo_target_constants=["2276"],
+            language="1001",
+            keywords=["shoes"],
+            limit=2,
+        )
+
+        self.assertEqual(len(results), 2)
+
+    def test_missing_seed_raises_tool_error(self):
+        with self.assertRaises(ToolError):
+            keyword_planner.generate_keyword_ideas(
+                customer_id="1234567890",
+                geo_target_constants=["2276"],
+                language="1001",
+            )
+
+
+class TestGenerateKeywordHistoricalMetrics(unittest.TestCase):
+    """Test cases for generate_keyword_historical_metrics."""
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_value")
+    def test_builds_request_and_formats_results(
+        self, mock_format, mock_get_service, mock_get_type
+    ):
+        request = MagicMock()
+        mock_get_type.return_value = request
+        service = MagicMock()
+        mock_get_service.return_value = service
+        response = MagicMock()
+        response.results = [MagicMock()]
+        service.generate_keyword_historical_metrics.return_value = response
+        mock_format.return_value = {"text": "shoes"}
+
+        results = keyword_planner.generate_keyword_historical_metrics(
+            customer_id="1234567890",
+            keywords=["shoes"],
+            geo_target_constants=["2276"],
+            language="1001",
+        )
+
+        mock_get_service.assert_called_once_with("KeywordPlanIdeaService")
+        request.keywords.extend.assert_called_once_with(["shoes"])
+        self.assertEqual(results, [{"text": "shoes"}])
+
+
+class TestReachPlanTools(unittest.TestCase):
+    """Test cases for the ReachPlanService tools."""
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_value")
+    def test_list_plannable_locations(
+        self, mock_format, mock_get_service, mock_get_type
+    ):
+        mock_get_type.return_value = MagicMock()
+        service = MagicMock()
+        mock_get_service.return_value = service
+        response = MagicMock()
+        response.plannable_locations = [MagicMock()]
+        service.list_plannable_locations.return_value = response
+        mock_format.return_value = {"id": "2276"}
+
+        results = keyword_planner.list_plannable_locations()
+
+        mock_get_service.assert_called_once_with("ReachPlanService")
+        self.assertEqual(results, [{"id": "2276"}])
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_value")
+    def test_list_plannable_products(
+        self, mock_format, mock_get_service, mock_get_type
+    ):
+        request = MagicMock()
+        mock_get_type.return_value = request
+        service = MagicMock()
+        mock_get_service.return_value = service
+        response = MagicMock()
+        response.product_metadata = [MagicMock()]
+        service.list_plannable_products.return_value = response
+        mock_format.return_value = {"plannable_product_code": "YOUTUBE"}
+
+        results = keyword_planner.list_plannable_products(
+            plannable_location_id="2276"
+        )
+
+        self.assertEqual(request.plannable_location_id, "2276")
+        self.assertEqual(results, [{"plannable_product_code": "YOUTUBE"}])
+
+
+class TestAudienceInsightsTools(unittest.TestCase):
+    """Test cases for the AudienceInsightsService tools."""
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_value")
+    def test_list_audience_insights_attributes(
+        self, mock_format, mock_get_service, mock_get_type
+    ):
+        request = MagicMock()
+        mock_get_type.return_value = request
+        service = MagicMock()
+        mock_get_service.return_value = service
+        response = MagicMock()
+        response.attributes = [MagicMock()]
+        service.list_audience_insights_attributes.return_value = response
+        mock_format.return_value = {"display_name": "Running"}
+
+        results = keyword_planner.list_audience_insights_attributes(
+            customer_id="1234567890",
+            dimensions=["AFFINITY_USER_INTEREST"],
+            query_text="running",
+        )
+
+        mock_get_service.assert_called_once_with("AudienceInsightsService")
+        self.assertEqual(request.customer_id, "1234567890")
+        self.assertEqual(request.dimensions, ["AFFINITY_USER_INTEREST"])
+        self.assertEqual(request.query_text, "running")
+        self.assertEqual(results, [{"display_name": "Running"}])
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_value")
+    def test_list_insights_eligible_dates(
+        self, mock_format, mock_get_service, mock_get_type
+    ):
+        mock_get_type.return_value = MagicMock()
+        service = MagicMock()
+        mock_get_service.return_value = service
+        response = MagicMock()
+        service.list_insights_eligible_dates.return_value = response
+        mock_format.return_value = {"data_months": ["2026-06"]}
+
+        result = keyword_planner.list_insights_eligible_dates()
+
+        mock_get_service.assert_called_once_with("AudienceInsightsService")
+        self.assertEqual(result, {"data_months": ["2026-06"]})
+
+
+class TestErrorTranslation(unittest.TestCase):
+    """Verifies GoogleAdsException is translated into a ToolError."""
+
+    @patch("ads_mcp.utils.get_googleads_type")
+    @patch("ads_mcp.utils.get_googleads_service")
+    def test_google_ads_exception_becomes_tool_error(
+        self, mock_get_service, mock_get_type
+    ):
+        from google.ads.googleads.errors import GoogleAdsException
+
+        mock_get_type.return_value = MagicMock()
+        service = MagicMock()
+        mock_get_service.return_value = service
+
+        mock_error = MagicMock()
+        mock_error.message = "Invalid geo target"
+        failure = MagicMock()
+        failure.errors = [mock_error]
+
+        ex = GoogleAdsException(
+            MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        )
+        ex.failure = failure
+        ex.request_id = "req-999"
+        service.list_plannable_locations.side_effect = ex
+
+        with self.assertRaises(ToolError) as context:
+            keyword_planner.list_plannable_locations()
+
+        self.assertIn("Invalid geo target", str(context.exception))
+        self.assertIn("Request ID: req-999", str(context.exception))

--- a/tests/tools/keyword_planner_test.py
+++ b/tests/tools/keyword_planner_test.py
@@ -241,6 +241,8 @@ class TestAudienceInsightsTools(unittest.TestCase):
 
         mock_get_service.assert_called_once_with("AudienceInsightsService")
         self.assertEqual(request.customer_id, "1234567890")
+        # customer_insights_group is a required API field; must be set.
+        self.assertEqual(request.customer_insights_group, "google-ads-mcp")
         self.assertEqual(request.dimensions, ["AFFINITY_USER_INTEREST"])
         self.assertEqual(request.query_text, "running")
         self.assertEqual(results, [{"display_name": "Running"}])

--- a/tests/usage_log/arguments_test.py
+++ b/tests/usage_log/arguments_test.py
@@ -1,0 +1,26 @@
+"""Covers runbook tests 5-7 (phase-2-middleware.md 2.11).
+Test 7 is the data-protection guarantee: an argument that is not on the
+whitelist must not reach the row, whatever it is called."""
+
+from ads_mcp.usage_log.arguments import read_account_id
+
+
+def test_reads_each_whitelisted_key():
+    assert read_account_id({"customer_id": 123}) == "123"
+    assert read_account_id({"merchant_id": "456"}) == "456"
+    assert read_account_id({"property_id": 789}) == "789"
+
+
+def test_returns_none_without_a_whitelisted_key():
+    assert read_account_id({"page_size": 50}) is None
+    assert read_account_id({}) is None
+    assert read_account_id(None) is None
+
+
+def test_ignores_every_other_argument():
+    arguments = {
+        "query": "SELECT campaign.name FROM campaign",
+        "filter": "customer@example.com",
+        "customer_id": 42,
+    }
+    assert read_account_id(arguments) == "42"

--- a/tests/usage_log/config_test.py
+++ b/tests/usage_log/config_test.py
@@ -1,0 +1,24 @@
+"""Startup config must fail loudly (phase-2-middleware.md 2.8).
+A missing DSN has to stop the server, not produce one that silently
+logs nothing — that blind spot is what this project exists to remove."""
+
+import pytest
+
+from ads_mcp.usage_log.config import DSN_ENV_VAR, read_dsn
+
+
+def test_returns_the_dsn(monkeypatch):
+    monkeypatch.setenv(DSN_ENV_VAR, "postgresql://user@host/db?sslmode=require")
+    assert read_dsn() == "postgresql://user@host/db?sslmode=require"
+
+
+def test_raises_when_unset(monkeypatch):
+    monkeypatch.delenv(DSN_ENV_VAR, raising=False)
+    with pytest.raises(RuntimeError, match=DSN_ENV_VAR):
+        read_dsn()
+
+
+def test_raises_when_empty(monkeypatch):
+    monkeypatch.setenv(DSN_ENV_VAR, "   ")
+    with pytest.raises(RuntimeError, match=DSN_ENV_VAR):
+        read_dsn()

--- a/tests/usage_log/identity_test.py
+++ b/tests/usage_log/identity_test.py
@@ -1,0 +1,39 @@
+"""Covers runbook tests 8-9 (phase-2-middleware.md 2.11).
+A missing email still yields an identity; a missing sub yields none at all,
+because user_sub is NOT NULL and a placeholder would read as a real person."""
+
+import ads_mcp.usage_log.identity as identity_module
+from ads_mcp.usage_log.identity import read_identity
+
+
+class FakeToken:
+    def __init__(self, claims):
+        self.claims = claims
+
+
+def _with_token(monkeypatch, token):
+    monkeypatch.setattr(identity_module, "get_access_token", lambda: token)
+
+
+def test_reads_sub_and_email(monkeypatch):
+    _with_token(monkeypatch, FakeToken({"sub": "1234", "email": "piotr@touchpoint.agency"}))
+    identity = read_identity()
+    assert identity == identity_module.Identity(sub="1234", email="piotr@touchpoint.agency")
+
+
+def test_missing_email_still_yields_identity(monkeypatch):
+    _with_token(monkeypatch, FakeToken({"sub": "1234", "email": None}))
+    identity = read_identity()
+    assert identity is not None
+    assert identity.sub == "1234"
+    assert identity.email is None
+
+
+def test_missing_sub_yields_no_identity(monkeypatch):
+    _with_token(monkeypatch, FakeToken({"email": "piotr@touchpoint.agency"}))
+    assert read_identity() is None
+
+
+def test_absent_token_yields_no_identity(monkeypatch):
+    _with_token(monkeypatch, None)
+    assert read_identity() is None

--- a/tests/usage_log/middleware_test.py
+++ b/tests/usage_log/middleware_test.py
@@ -1,0 +1,133 @@
+"""Covers runbook tests 1-3 (phase-2-middleware.md 2.11).
+The middleware is an observer: it must not alter a result, swallow an
+exception, or let its own failure reach the caller."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import ads_mcp.usage_log.identity as identity_module
+from ads_mcp.usage_log.middleware import UsageLogMiddleware
+from ads_mcp.usage_log.sink import ToolCall
+
+TIMESTAMP = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeToken:
+    claims = {"sub": "1234", "email": "piotr@touchpoint.agency"}
+
+
+class RecordingSink:
+    def __init__(self):
+        self.calls: list[ToolCall] = []
+
+    async def write(self, call: ToolCall) -> None:
+        self.calls.append(call)
+
+
+class FailingSink:
+    async def write(self, call: ToolCall) -> None:
+        raise RuntimeError("database is down")
+
+
+class FakeResult:
+    def __init__(self, is_error: bool = False):
+        self.is_error = is_error
+
+
+@pytest.fixture(autouse=True)
+def authenticated(monkeypatch):
+    monkeypatch.setattr(identity_module, "get_access_token", lambda: FakeToken())
+
+
+def _context(tool: str = "list_products", arguments: dict | None = None):
+    return SimpleNamespace(
+        timestamp=TIMESTAMP,
+        message=SimpleNamespace(name=tool, arguments=arguments or {"merchant_id": 42}),
+    )
+
+
+async def test_successful_call_is_logged_as_ok():
+    sink = RecordingSink()
+    middleware = UsageLogMiddleware(server="google-merchant", sink=sink)
+    result = FakeResult()
+
+    returned = await middleware.on_call_tool(_context(), lambda ctx: _returns(result))
+
+    assert returned is result
+    assert sink.calls == [
+        ToolCall(
+            occurred_at=TIMESTAMP,
+            server="google-merchant",
+            tool="list_products",
+            user_sub="1234",
+            user_email="piotr@touchpoint.agency",
+            account_id="42",
+            status="ok",
+        )
+    ]
+
+
+async def test_raising_tool_is_logged_as_error_and_reraised():
+    sink = RecordingSink()
+    middleware = UsageLogMiddleware(server="google-merchant", sink=sink)
+    failure = ValueError("upstream exploded")
+
+    with pytest.raises(ValueError) as raised:
+        await middleware.on_call_tool(_context(), lambda ctx: _raises(failure))
+
+    assert raised.value is failure
+    assert [call.status for call in sink.calls] == ["error"]
+
+
+async def test_error_result_is_logged_as_error_and_returned_unchanged():
+    sink = RecordingSink()
+    middleware = UsageLogMiddleware(server="google-merchant", sink=sink)
+    result = FakeResult(is_error=True)
+
+    returned = await middleware.on_call_tool(_context(), lambda ctx: _returns(result))
+
+    assert returned is result
+    assert [call.status for call in sink.calls] == ["error"]
+
+
+async def test_sink_failure_does_not_break_the_tool_call():
+    middleware = UsageLogMiddleware(server="google-merchant", sink=FailingSink())
+    result = FakeResult()
+
+    returned = await middleware.on_call_tool(_context(), lambda ctx: _returns(result))
+
+    assert returned is result
+
+
+async def test_missing_sub_writes_nothing_but_still_serves_the_call(monkeypatch):
+    monkeypatch.setattr(identity_module, "get_access_token", lambda: None)
+    sink = RecordingSink()
+    middleware = UsageLogMiddleware(server="google-merchant", sink=sink)
+    result = FakeResult()
+
+    returned = await middleware.on_call_tool(_context(), lambda ctx: _returns(result))
+
+    assert returned is result
+    assert sink.calls == []
+
+
+async def test_unlisted_arguments_never_reach_the_row():
+    sink = RecordingSink()
+    middleware = UsageLogMiddleware(server="google-ads", sink=sink)
+    context = _context(arguments={"query": "SELECT campaign.name FROM campaign"})
+
+    await middleware.on_call_tool(context, lambda ctx: _returns(FakeResult()))
+
+    written = sink.calls[0]
+    assert written.account_id is None
+    assert "campaign" not in repr(written)
+
+
+async def _returns(value):
+    return value
+
+
+async def _raises(error):
+    raise error

--- a/tests/usage_log/sink_test.py
+++ b/tests/usage_log/sink_test.py
@@ -1,0 +1,87 @@
+"""Covers runbook test 4 against a real Postgres (phase-2-middleware.md 2.11).
+Skipped without MCP_USAGE_TEST_DSN, because the database is a backing service
+the developer provides, not something this repo runs."""
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import psycopg
+import pytest
+
+from ads_mcp.usage_log.sink import PostgresSink, ToolCall
+
+TEST_DSN = os.environ.get("MCP_USAGE_TEST_DSN", "")
+
+pytestmark = pytest.mark.skipif(not TEST_DSN, reason="MCP_USAGE_TEST_DSN is not set")
+
+
+def _call(server: str, **overrides) -> ToolCall:
+    fields = {
+        "occurred_at": datetime.now(timezone.utc),
+        "server": server,
+        "tool": "list_products",
+        "user_sub": "1234567890",
+        "user_email": "piotr@touchpoint.agency",
+        "account_id": "42",
+        "status": "ok",
+        **overrides,
+    }
+    return ToolCall(**fields)
+
+
+@pytest.fixture
+def marker() -> str:
+    return f"test-{uuid.uuid4()}"
+
+
+@pytest.fixture
+def cleanup(marker):
+    yield
+    with psycopg.connect(TEST_DSN) as conn:
+        conn.execute("DELETE FROM tool_call WHERE server = %s", (marker,))
+
+
+async def test_writes_every_field(marker, cleanup):
+    sink = PostgresSink(TEST_DSN)
+    call = _call(marker)
+    await sink.write(call)
+    await sink.close()
+
+    with psycopg.connect(TEST_DSN) as conn:
+        row = conn.execute(
+            "SELECT occurred_at, server, tool, user_sub, user_email, account_id, status"
+            " FROM tool_call WHERE server = %s",
+            (marker,),
+        ).fetchone()
+
+    assert row == (
+        call.occurred_at,
+        marker,
+        "list_products",
+        "1234567890",
+        "piotr@touchpoint.agency",
+        "42",
+        "ok",
+    )
+
+
+async def test_writes_nullable_fields_as_null(marker, cleanup):
+    sink = PostgresSink(TEST_DSN)
+    await sink.write(_call(marker, user_email=None, account_id=None))
+    await sink.close()
+
+    with psycopg.connect(TEST_DSN) as conn:
+        row = conn.execute(
+            "SELECT user_email, account_id FROM tool_call WHERE server = %s",
+            (marker,),
+        ).fetchone()
+
+    assert row == (None, None)
+
+
+async def test_unreachable_database_raises_within_the_timeout():
+    sink = PostgresSink("postgresql://nobody@127.0.0.1:1/nothing?connect_timeout=1")
+    with pytest.raises(Exception):
+        await sink.write(_call("unreachable"))
+    await sink.close()


### PR DESCRIPTION
Jeder Tool-Aufruf schreibt eine Zeile nach `mcp_usage.tool_call`: Zeitstempel, Server, Tool, Person aus dem OAuth-Token, Account-ID, Status. Gleiches Vorgehen wie bei `google-merchant-mcp`, dort seit dem 2026-08-03 in Betrieb.

Der Code ist kopiert, nicht als Paket eingebunden. Eine echte Abhängigkeit auf das private `tp-mcp-usage-log` bräuchte einen PAT als Build-Secret und Token-Handling im Dockerfile — ein zusätzliches Geheimnis mit Ablaufdatum, nur fürs Verpacken. Sobald alle drei Server laufen, wird daraus wieder ein Paket, dann aus einem öffentlichen Repo und weiterhin ohne Token.

## Zusagen

- Eine tote Log-Datenbank darf keinen Tool-Aufruf verhindern: Schreibfehler werden geschluckt und geloggt, Timeout 2s. Gegen den echten Container bei Merchant nachgewiesen.
- Fehlt `MCP_USAGE_DSN`, startet der Server gar nicht erst.
- Nur die Account-ID wird gespeichert, nie Suchbegriffe oder Filter.

## Sub-Server

Dieses Repo mountet seine Tools über `parent_mcp.mount(...)`, die Tools hängen also nicht direkt am Hauptserver. Nachgestellt: Middleware am Parent feuert auch für gemountete Tools, der Name kommt mit Namespace an (`customers_list_accessible_customers`), die Argumente bleiben intakt — `customer_id` wird also gefunden.

## Zwei Sicherheitsfunde, hier mitgenommen

**Access-Token im Log.** fastmcps `GoogleProvider` prüft jeden Request gegen Googles `tokeninfo`-Endpoint, der den Token als Query-Parameter nimmt; httpx loggt auf INFO die volle URL. Ergebnis: bei jedem Request steht ein gültiger `ya29.…`-Token im Dokploy-Log. httpx wird jetzt auf WARNING gesetzt — beide Logger-Namen, weil fastmcp 3 `httpx` nutzt und fastmcp 4 den Fork `httpx2`. Bei Merchant bereits gefixt und im Log verifiziert.

**Kein `.dockerignore` bei `COPY . .`.** Damit landet alles im Image, inklusive `.git` und einer eventuellen `.env` — Dokploys „Create Environment File" legt genau so eine neben das Dockerfile. Jetzt ausgeschlossen. Lokal gebaut und geprüft: `.git` ist raus, alle 9 Tools laden weiterhin, `fastmcp 3.4.2` und `psycopg 3.3.4` im Image.

## Test

`pytest --ignore=tests/smoke` — vorher 50 passed, jetzt 66 passed, 3 skipped (die 3 brauchen eine echte Datenbank). Keine Regression durch `asyncio_mode = "auto"`.

Ohne OAuth-Variablen startet der Server sauber und baut die Middleware nicht. Mit OAuth und ohne DSN bricht er mit `MCP_USAGE_DSN is unset or empty` ab.

`tests/smoke` war schon vor diesem PR nicht sammelbar (`No module named 'google.genai'`) und ist unverändert.

## Nicht Teil dieses PRs

Das Repo hat kein Lockfile; das Dockerfile pinnt nur `fastmcp==3.4.2` per zweitem `uv pip install`, alle anderen Abhängigkeiten lösen bei jedem Build frisch auf. Eigener Fix.

## Deploy

`MCP_USAGE_DSN` liegt bereits in Dokploy. Branch `main`, Trigger On Push — Merge löst den Deploy aus.
