### PR TITLE
Add Firestore as a client_storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,17 @@ To enable it, set the following environment variables:
 - `GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET`: Your Google Cloud OAuth 2.0 Client Secret.
 - `GOOGLE_ADS_MCP_BASE_URL`: (Optional) The base URL where the server is accessible (defaults to `http://localhost:8080`).
 - `GOOGLE_ADS_MCP_JWT_SIGNING_KEY`: (Optional) Secret key used to sign FastMCP JWT tokens across multiple server instances or deployments.
-- `GOOGLE_ADS_MCP_STORAGE_TYPE`: (Optional) Storage backend for OAuth state (`filetree`, `redis`, or `memory`).
+- `GOOGLE_ADS_MCP_STORAGE_TYPE`: (Optional) Storage backend for OAuth state (`filetree`, `redis`, `firestore`, or `memory`).
 - `GOOGLE_ADS_MCP_STORAGE_PATH`: (Optional) Directory path for `filetree` persistent storage.
 - `GOOGLE_ADS_MCP_STORAGE_REDIS_URL`: (Optional) Redis URL for `redis` persistent storage.
+- `GOOGLE_ADS_MCP_STORAGE_FIRESTORE_PROJECT`: (Optional) Google Cloud project for `firestore` persistent storage. Defaults to the project inferred from Application Default Credentials. Setting it selects the `firestore` backend even if `GOOGLE_ADS_MCP_STORAGE_TYPE` is unset.
+- `GOOGLE_ADS_MCP_STORAGE_FIRESTORE_DATABASE`: (Optional) Firestore database name for `firestore` persistent storage. Defaults to `(default)`.
 - `GOOGLE_ADS_MCP_STORAGE_ENCRYPTION_KEY`: (Optional) Encryption key for stored OAuth tokens.
 - `GOOGLE_ADS_MCP_STORAGE_DISABLE_ENCRYPTION`: (Optional) Set to `true` to disable token encryption.
+
+The `redis` and `firestore` backends need their storage library installed
+alongside the server: `pip install py-key-value-aio[redis]` and
+`pip install google-ads-mcp[firestore]` respectively.
 
 Once this is enabled, you can authenticate to the API through your MCP client.
 
@@ -326,7 +332,17 @@ Make sure to set the required environment variables:
 - `GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET`: The OAuth Client secret you want the MCP server to use.
 - `GOOGLE_ADS_MCP_BASE_URL`: The base URL where your MCP server is accessible: this will be automatically assigned by Google Cloud Run after your first deployment. You can update the environment variables after deployment. 
 - `GOOGLE_ADS_MCP_JWT_SIGNING_KEY`: (Recommended for production) Persistent JWT signing key across Cloud Run instances.
-- `GOOGLE_ADS_MCP_STORAGE_TYPE` / `GOOGLE_ADS_MCP_STORAGE_REDIS_URL`: (Recommended for production) Storage backend (e.g. `redis`) to persist OAuth tokens across instances.
+- `GOOGLE_ADS_MCP_STORAGE_TYPE`: (Recommended for production) Storage backend to persist OAuth tokens across instances. Set it to `firestore` to use Firestore through Application Default Credentials, which needs no VPC connector, or to `redis` along with `GOOGLE_ADS_MCP_STORAGE_REDIS_URL`.
+
+  Using `firestore` requires three things: build the image with the extra
+  installed (change the Dockerfile to `uv pip install --system .[firestore]`),
+  create a Firestore database in the project, since one is not provisioned
+  automatically, and grant the Cloud Run service account `roles/datastore.user`.
+  Note that entries are not expired automatically: the store filters expired
+  entries on read but never deletes them, and `expires_at` is written as a
+  string, so a Firestore TTL policy cannot collect them either. Plan on a
+  periodic cleanup job for long-running deployments. Redis expires entries on
+  its own.
 - `FASTMCP_HOST`: Set this to `0.0.0.0` to allow FastMCP to accept connections from all IP addresses.
 
 ```shell
@@ -335,7 +351,7 @@ gcloud run deploy google-ads-mcp \
   --platform managed \
   --region us-central1 \
   --allow-unauthenticated \
-  --set-env-vars="GOOGLE_PROJECT_ID=YOUR_PROJECT_ID,GOOGLE_ADS_DEVELOPER_TOKEN=YOUR_DEVELOPER_TOKEN,GOOGLE_ADS_MCP_OAUTH_CLIENT_ID=YOUR_CLIENT_ID,GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET=YOUR_CLIENT_SECRET,GOOGLE_ADS_MCP_BASE_URL=YOUR_BASE_URL,GOOGLE_ADS_MCP_JWT_SIGNING_KEY=YOUR_JWT_SIGNING_KEY,FASTMCP_HOST=0.0.0.0"
+  --set-env-vars="GOOGLE_PROJECT_ID=YOUR_PROJECT_ID,GOOGLE_ADS_DEVELOPER_TOKEN=YOUR_DEVELOPER_TOKEN,GOOGLE_ADS_MCP_OAUTH_CLIENT_ID=YOUR_CLIENT_ID,GOOGLE_ADS_MCP_OAUTH_CLIENT_SECRET=YOUR_CLIENT_SECRET,GOOGLE_ADS_MCP_BASE_URL=YOUR_BASE_URL,GOOGLE_ADS_MCP_JWT_SIGNING_KEY=YOUR_JWT_SIGNING_KEY,GOOGLE_ADS_MCP_STORAGE_TYPE=firestore,FASTMCP_HOST=0.0.0.0"
 ```
 
 ### Step 3: Configure MCP Client

--- a/ads_mcp/auth_storage.py
+++ b/ads_mcp/auth_storage.py
@@ -25,17 +25,21 @@ if TYPE_CHECKING:
 def create_client_storage() -> Any:
     """Creates an AsyncKeyValue store for FastMCP client_storage based on environment variables.
 
-    Supports 'filetree', 'redis', and 'memory' storage backends.
+    Supports 'filetree', 'redis', 'firestore', and 'memory' storage backends.
     If no storage configuration is provided, returns None to allow FastMCP to use its
     default storage logic.
     """
     st_type = os.environ.get("GOOGLE_ADS_MCP_STORAGE_TYPE")
     st_path = os.environ.get("GOOGLE_ADS_MCP_STORAGE_PATH")
     r_url = os.environ.get("GOOGLE_ADS_MCP_STORAGE_REDIS_URL")
+    fs_project = os.environ.get("GOOGLE_ADS_MCP_STORAGE_FIRESTORE_PROJECT")
+    fs_database = os.environ.get("GOOGLE_ADS_MCP_STORAGE_FIRESTORE_DATABASE")
 
     if not st_type:
         if r_url:
             st_type = "redis"
+        elif fs_project or fs_database:
+            st_type = "firestore"
         elif st_path:
             st_type = "filetree"
         else:
@@ -59,13 +63,50 @@ def create_client_storage() -> Any:
 
         url_to_use = r_url or "redis://localhost:6379/0"
         store = RedisStore(url=url_to_use)
+    elif st_type == "firestore":
+        try:
+            from key_value.aio.stores.firestore import (
+                FirestoreStore,
+                FirestoreV1CollectionSanitizationStrategy,
+                FirestoreV1KeySanitizationStrategy,
+            )
+        except ImportError as exc:
+            raise ValueError(
+                "Firestore storage requires the firestore extra. Install it "
+                "with 'pip install py-key-value-aio[firestore]'."
+            ) from exc
+
+        from google.auth.exceptions import DefaultCredentialsError
+
+        # Both project and database are optional: when omitted, the store falls
+        # back to Application Default Credentials and the '(default)' database,
+        # which is what a Cloud Run deployment normally wants.
+        # The sanitization strategies are needed because CIMD client ids are
+        # URLs, and Firestore rejects the '/' they contain in a document id.
+        try:
+            store = FirestoreStore(
+                project=fs_project,
+                database=fs_database,
+                key_sanitization_strategy=(
+                    FirestoreV1KeySanitizationStrategy()
+                ),
+                collection_sanitization_strategy=(
+                    FirestoreV1CollectionSanitizationStrategy()
+                ),
+            )
+        except DefaultCredentialsError as exc:
+            raise ValueError(
+                "Firestore storage could not resolve Application Default "
+                "Credentials. Configure ADC for this environment, or set "
+                "GOOGLE_ADS_MCP_STORAGE_TYPE to a different backend."
+            ) from exc
     elif st_type == "memory":
         from key_value.aio.stores.memory import MemoryStore
 
         store = MemoryStore()
     else:
         raise ValueError(
-            f"Unsupported client storage type: '{st_type}'. Expected one of: filetree, redis, memory."
+            f"Unsupported client storage type: '{st_type}'. Expected one of: filetree, redis, firestore, memory."
         )
 
     dis_enc = os.environ.get(

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,6 +34,8 @@ FREEZE_COMMAND = [sys.executable, "-m", "pip", "freeze"]
 TEST_DEPENDENCIES = [
     "pyfakefs>=5.0.0,<6.0",
     "coverage==6.5.0",
+    # Lets the firestore storage backend tests run instead of being skipped.
+    "py-key-value-aio[firestore] >=0.4.5, <0.5.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ dev = [
     "black",
     "nox >=2025.5.1, <2026"
 ]
+firestore = [
+    # 0.4.5 is the first release exposing the Firestore sanitization strategies.
+    "py-key-value-aio[firestore] >=0.4.5, <0.5.0"
+]
 
 [project.urls]
 homepage = "https://github.com/googleads/google-ads-mcp"

--- a/tests/auth_config_test.py
+++ b/tests/auth_config_test.py
@@ -33,6 +33,14 @@ except ImportError:
     HAS_REDIS = False
     RedisStore = None
 
+try:
+    from key_value.aio.stores.firestore import FirestoreStore
+
+    HAS_FIRESTORE = True
+except ImportError:
+    HAS_FIRESTORE = False
+    FirestoreStore = None
+
 from ads_mcp.auth_storage import create_client_storage
 
 
@@ -50,6 +58,8 @@ class TestAuthConfig(unittest.TestCase):
             "GOOGLE_ADS_MCP_STORAGE_TYPE",
             "GOOGLE_ADS_MCP_STORAGE_PATH",
             "GOOGLE_ADS_MCP_STORAGE_REDIS_URL",
+            "GOOGLE_ADS_MCP_STORAGE_FIRESTORE_PROJECT",
+            "GOOGLE_ADS_MCP_STORAGE_FIRESTORE_DATABASE",
             "GOOGLE_ADS_MCP_STORAGE_ENCRYPTION_KEY",
             "GOOGLE_ADS_MCP_STORAGE_DISABLE_ENCRYPTION",
             "GOOGLE_ADS_MCP_JWT_SIGNING_KEY",
@@ -115,6 +125,41 @@ class TestAuthConfig(unittest.TestCase):
         os.environ["GOOGLE_ADS_MCP_STORAGE_DISABLE_ENCRYPTION"] = "true"
         store = create_client_storage()
         self.assertIsInstance(store, RedisStore)
+
+    @unittest.skipUnless(HAS_FIRESTORE, "firestore package not installed")
+    @patch("key_value.aio.stores.firestore.FirestoreStore")
+    def test_create_client_storage_firestore(self, mock_store):
+        """Tests creating a firestore store.
+
+        The store is patched because building a real one resolves Application
+        Default Credentials, which are not available in every test
+        environment. The sanitization strategies are asserted because dropping
+        them would leave CIMD client ids, which are URLs, as invalid Firestore
+        document ids.
+        """
+        os.environ["GOOGLE_ADS_MCP_STORAGE_TYPE"] = "firestore"
+        os.environ["GOOGLE_ADS_MCP_STORAGE_FIRESTORE_PROJECT"] = "test-project"
+        os.environ["GOOGLE_ADS_MCP_STORAGE_FIRESTORE_DATABASE"] = "test-db"
+        os.environ["GOOGLE_ADS_MCP_STORAGE_DISABLE_ENCRYPTION"] = "true"
+        store = create_client_storage()
+        _, kwargs = mock_store.call_args
+        self.assertEqual(kwargs["project"], "test-project")
+        self.assertEqual(kwargs["database"], "test-db")
+        self.assertIn("key_sanitization_strategy", kwargs)
+        self.assertIn("collection_sanitization_strategy", kwargs)
+        self.assertIs(store, mock_store.return_value)
+
+    @unittest.skipUnless(HAS_FIRESTORE, "firestore package not installed")
+    @patch("key_value.aio.stores.firestore.FirestoreStore")
+    def test_create_client_storage_firestore_env_var(self, mock_store):
+        """Tests that the firestore project alone selects firestore."""
+        os.environ["GOOGLE_ADS_MCP_STORAGE_FIRESTORE_PROJECT"] = "test-project"
+        os.environ["GOOGLE_ADS_MCP_STORAGE_DISABLE_ENCRYPTION"] = "true"
+        store = create_client_storage()
+        _, kwargs = mock_store.call_args
+        self.assertEqual(kwargs["project"], "test-project")
+        self.assertIsNone(kwargs["database"])
+        self.assertIs(store, mock_store.return_value)
 
     def test_create_client_storage_disable_encryption(self):
         """Tests disabling encryption wrapper."""


### PR DESCRIPTION
## Problem

`create_client_storage()` accepts only `filetree`, `redis` and `memory`, so persisting OAuth state across Cloud Run instances currently means running Memorystore behind a VPC connector — a fair amount of infrastructure for what is just a key-value store.

## Change

`py-key-value-aio` already ships a `FirestoreStore` satisfying the same `AsyncKeyValue` protocol that `OAuthProxy` expects, so it drops into the existing branch:

- `GOOGLE_ADS_MCP_STORAGE_TYPE=firestore` selects it, and setting `GOOGLE_ADS_MCP_STORAGE_FIRESTORE_PROJECT` or `_DATABASE` selects it too, matching how the redis url and the filetree path already work.
- Both are optional and fall back to Application Default Credentials and the `(default)` database, so on Cloud Run no networking setup is needed.
- The V1 sanitization strategies are passed because CIMD client ids are URLs, and Firestore rejects the `/` they contain in a document id.
- The import stays inside the branch like the other backends, so nothing new is imported unless Firestore is selected. The extra is declared as an optional dependency, and a missing extra or unresolvable credentials each raise a `ValueError` naming the fix rather than a bare traceback.

The extra is added to the nox test dependencies so the new tests run in CI, and the tests patch the store rather than building a real client.

README covers the prerequisites: creating the Firestore database, granting the service account `roles/datastore.user`, building the image with the extra, and the fact that entries are not expired automatically.

## Validation

- `nox -s lint` passes, and the auth storage tests pass with the new Firestore cases running rather than being skipped.
- Ran the server locally against a real Firestore database with `GOOGLE_ADS_MCP_STORAGE_TYPE=firestore` and completed a full OAuth flow: dynamic client registration, authorization, Google sign-in, and code exchange. Client registrations, transactions, upstream tokens, refresh token metadata and JTI mappings were all persisted to Firestore, Fernet-encrypted.
- Both failure paths were exercised manually: a missing firestore extra and unresolvable Application Default Credentials each raise the intended `ValueError`.

## Note

`FirestoreStore` does not declare `stable_api=True`, unlike `filetree`, `redis` and `memory`, so selecting it emits a "store is unstable" `UserWarning`. It only affects users who opt into `firestore` — the module is not imported otherwise. Happy to adjust or close this if you would rather wait for upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
