### PR TITLE
Add Google Ads API v25 support and preserve empty search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains the source code for running an
 ## Tools
 
 The server uses the
-[Google Ads API](https://developers.google.com/google-ads/api/reference/rpc/latest/overview)
+[Google Ads API v25](https://developers.google.com/google-ads/api/reference/rpc/v25/overview)
 to provide several
 [Tools](https://modelcontextprotocol.io/docs/concepts/tools) and [Resources](https://modelcontextprotocol.io/docs/concepts/tools) for use with LLMs and AI agents.
 
@@ -50,7 +50,7 @@ namespaces:
 
 ### Resources available
 
-- `discovery-document`: Retrieve the Google Ads API discovery document. Provides the discovery document for the latest version of the Google Ads API, which describes the API surface, including resources, methods, and schemas. Host LLMs should access this resource to understand the structure of the Google Ads API and discover available features.
+- `discovery-document`: Retrieve the Google Ads API discovery document. Provides the discovery document for the configured v25 Google Ads API contract, which describes the API surface, including resources, methods, and schemas. Host LLMs should access this resource to understand the structure of the Google Ads API and discover available features.
 - `metrics`: Retrieve information about the metrics available for reporting in the Google Ads API.
 - `segments`: Retrieve information about the segments available for reporting in the Google Ads API.
 - `release-notes`: Retrieve the release notes for the latest version of the Google Ads API.

--- a/ads_mcp/gaql_resources.txt
+++ b/ads_mcp/gaql_resources.txt
@@ -60,7 +60,6 @@ campaign_draft
 campaign_goal_config
 campaign_group
 campaign_label
-campaign_lifecycle_goal
 campaign_search_term_insight
 campaign_search_term_view
 campaign_shared_set
@@ -89,7 +88,6 @@ customer_client_link
 customer_conversion_goal
 customer_customizer
 customer_label
-customer_lifecycle_goal
 customer_manager_link
 customer_negative_criterion
 customer_search_term_insight

--- a/ads_mcp/gaql_resources.txt
+++ b/ads_mcp/gaql_resources.txt
@@ -26,6 +26,7 @@ ai_max_search_term_ad_combination_view
 android_privacy_shared_key_google_ad_group
 android_privacy_shared_key_google_campaign
 android_privacy_shared_key_google_network_type
+app_top_combination_view
 applied_incentive
 asset
 asset_field_type_view
@@ -65,6 +66,7 @@ campaign_search_term_view
 campaign_shared_set
 campaign_simulation
 carrier_constant
+cart_data_sales_view
 change_event
 change_status
 channel_aggregate_asset_view
@@ -139,6 +141,7 @@ matched_location_interest_view
 media_file
 mobile_app_category_constant
 mobile_device_constant
+multi_party_auth_review
 offline_conversion_upload_client_summary
 offline_conversion_upload_conversion_action_summary
 offline_user_data_job
@@ -173,5 +176,6 @@ user_list
 user_list_customer_type
 user_location_view
 video
+video_enhancement
 webpage_view
 you_tube_video_upload

--- a/ads_mcp/resources/discovery.py
+++ b/ads_mcp/resources/discovery.py
@@ -17,6 +17,7 @@
 import urllib.request
 
 from ads_mcp.coordinator import mcp
+from ads_mcp.utils import GOOGLE_ADS_API_VERSION
 
 
 @mcp.resource(
@@ -38,7 +39,10 @@ def get_discovery_document() -> str:
     Returns:
         str: The discovery document in JSON format.
     """
-    url = "https://googleads.googleapis.com/$discovery/rest?version=v24"
+    url = (
+        "https://googleads.googleapis.com/$discovery/rest"
+        f"?version={GOOGLE_ADS_API_VERSION}"
+    )
     req = urllib.request.Request(
         url,
         headers={"User-Agent": "Mozilla/5.0"},

--- a/ads_mcp/resources/metrics.py
+++ b/ads_mcp/resources/metrics.py
@@ -17,6 +17,7 @@
 import urllib.request
 
 from ads_mcp.coordinator import mcp
+from ads_mcp.utils import GOOGLE_ADS_API_VERSION
 
 
 @mcp.resource(
@@ -37,7 +38,10 @@ def get_metrics() -> str:
     Returns:
         str: The metrics documentation in HTML format.
     """
-    url = "https://developers.google.com/google-ads/api/fields/latest/metrics"
+    url = (
+        "https://developers.google.com/google-ads/api/fields/"
+        f"{GOOGLE_ADS_API_VERSION}/metrics"
+    )
     req = urllib.request.Request(
         url,
         headers={"User-Agent": "Mozilla/5.0"},

--- a/ads_mcp/resources/segments.py
+++ b/ads_mcp/resources/segments.py
@@ -17,6 +17,7 @@
 import urllib.request
 
 from ads_mcp.coordinator import mcp
+from ads_mcp.utils import GOOGLE_ADS_API_VERSION
 
 
 @mcp.resource(
@@ -37,7 +38,10 @@ def get_segments() -> str:
     Returns:
         str: The segments documentation in HTML format.
     """
-    url = "https://developers.google.com/google-ads/api/fields/latest/segments"
+    url = (
+        "https://developers.google.com/google-ads/api/fields/"
+        f"{GOOGLE_ADS_API_VERSION}/segments"
+    )
     req = urllib.request.Request(
         url,
         headers={"User-Agent": "Mozilla/5.0"},

--- a/ads_mcp/tools/core.py
+++ b/ads_mcp/tools/core.py
@@ -20,7 +20,7 @@ from mcp.types import ToolAnnotations
 
 import ads_mcp.utils as utils
 
-from google.ads.googleads.v24.services.types.customer_service import (
+from google.ads.googleads.v25.services.types.customer_service import (
     ListAccessibleCustomersResponse,
 )
 

--- a/ads_mcp/tools/search.py
+++ b/ads_mcp/tools/search.py
@@ -14,7 +14,7 @@
 
 """Tools for exposing the API Search method to the MCP server."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TypedDict
 from fastmcp import FastMCP
 from fastmcp.tools import Tool
 from mcp.types import ToolAnnotations
@@ -26,6 +26,10 @@ from google.ads.googleads.errors import GoogleAdsException
 from fastmcp.exceptions import ToolError
 
 
+class SearchResult(TypedDict):
+    result: List[Dict[str, Any]]
+
+
 def search(
     customer_id: str,
     fields: List[str],
@@ -33,7 +37,7 @@ def search(
     conditions: List[str] = [],
     orderings: List[str] = [],
     limit: int | None = None,
-) -> List[Dict[str, Any]]:
+) -> SearchResult:
     """Fetches data from the Google Ads API using the search method
 
     Args:
@@ -69,13 +73,13 @@ def search(
             customer_id=customer_id, query=query
         )
 
-        final_output: List = []
+        final_output: List[Dict[str, Any]] = []
         for batch in query_result:
             for row in batch.results:
                 final_output.append(
                     utils.format_output_row(row, batch.field_mask.paths)
                 )
-        return final_output
+        return {"result": final_output}
     except GoogleAdsException as ex:
         error_msgs = [
             f"Google Ads API Error: {error.message}"

--- a/ads_mcp/tools/search.py
+++ b/ads_mcp/tools/search.py
@@ -105,7 +105,7 @@ def _search_tool_description() -> str:
 
 ### Hints
     Language Grammar can be found at https://developers.google.com/google-ads/api/docs/query/grammar
-    All resources and descriptions are found at https://developers.google.com/google-ads/api/fields/latest/overview
+    All resources and descriptions are found at https://developers.google.com/google-ads/api/fields/{utils.GOOGLE_ADS_API_VERSION}/overview
     If the query fails, a ToolError will be raised with the error details.
 
     For Conversion issues try looking in offline_conversion_upload_conversion_action_summary

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -20,7 +20,7 @@ from typing import Any
 import proto
 import logging
 from google.ads.googleads.client import GoogleAdsClient
-from google.ads.googleads.v24.services.services.google_ads_service import (
+from google.ads.googleads.v25.services.services.google_ads_service import (
     GoogleAdsServiceClient,
 )
 
@@ -35,6 +35,10 @@ from unittest.mock import patch
 
 # filename for generated field information used by search
 _GAQL_FILENAME = "gaql_resources.txt"
+
+# Keep every service, message, and public discovery request on the reviewed
+# Google Ads API contract instead of relying on the client library default.
+GOOGLE_ADS_API_VERSION = "v25"
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -114,12 +118,16 @@ def _get_googleads_client() -> GoogleAdsClient:
 
 def get_googleads_service(serviceName: str) -> GoogleAdsServiceClient:
     return _get_googleads_client().get_service(
-        serviceName, interceptors=[MCPHeaderInterceptor()]
+        serviceName,
+        version=GOOGLE_ADS_API_VERSION,
+        interceptors=[MCPHeaderInterceptor()],
     )
 
 
 def get_googleads_type(typeName: str):
-    return _get_googleads_client().get_type(typeName)
+    return _get_googleads_client().get_type(
+        typeName, version=GOOGLE_ADS_API_VERSION
+    )
 
 
 def get_googleads_client():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 dependencies = [
-    "google-ads>=31.0.0",
+    "google-ads==31.2.0",
     "mcp[cli]>=1.2.0",
     "fastmcp>=3.2.0"
 ]

--- a/tests/resources/discovery_test.py
+++ b/tests/resources/discovery_test.py
@@ -44,6 +44,6 @@ class DiscoveryTest(unittest.TestCase):
         self.assertIsInstance(request_obj, urllib.request.Request)
         self.assertEqual(
             request_obj.full_url,
-            "https://googleads.googleapis.com/$discovery/rest?version=v24",
+            "https://googleads.googleapis.com/$discovery/rest?version=v25",
         )
         self.assertEqual(request_obj.headers.get("User-agent"), "Mozilla/5.0")

--- a/tests/resources/metrics_test.py
+++ b/tests/resources/metrics_test.py
@@ -44,6 +44,6 @@ class MetricsTest(unittest.TestCase):
         self.assertIsInstance(request_obj, urllib.request.Request)
         self.assertEqual(
             request_obj.full_url,
-            "https://developers.google.com/google-ads/api/fields/latest/metrics",
+            "https://developers.google.com/google-ads/api/fields/v25/metrics",
         )
         self.assertEqual(request_obj.headers.get("User-agent"), "Mozilla/5.0")

--- a/tests/resources/segments_test.py
+++ b/tests/resources/segments_test.py
@@ -44,6 +44,6 @@ class SegmentsTest(unittest.TestCase):
         self.assertIsInstance(request_obj, urllib.request.Request)
         self.assertEqual(
             request_obj.full_url,
-            "https://developers.google.com/google-ads/api/fields/latest/segments",
+            "https://developers.google.com/google-ads/api/fields/v25/segments",
         )
         self.assertEqual(request_obj.headers.get("User-agent"), "Mozilla/5.0")

--- a/tests/smoke/golden_tools_list.json
+++ b/tests/smoke/golden_tools_list.json
@@ -70,24 +70,21 @@
       "annotations": {
         "readOnlyHint": true
       },
-      "description": "Fetches data from the Google Ads API using the search method",
+      "description": "Fetches data from the Google Ads API using the search method\n\n    Args:\n        customer_id: The id of the customer\n        fields: The fields to fetch\n        resource: The resource to return fields from\n        conditions: List of conditions to filter the data, combined using AND clauses\n        orderings: How the data is ordered\n        limit: The maximum number of rows to return\n\n    \n\n### Hints\n    Language Grammar can be found at https://developers.google.com/google-ads/api/docs/query/grammar\n    All resources and descriptions are found at https://developers.google.com/google-ads/api/fields/v25/overview\n    If the query fails, a ToolError will be raised with the error details.\n\n    For Conversion issues try looking in offline_conversion_upload_conversion_action_summary\n\n### Hint for customer_id\n    should be a string of numbers without punctuation\n    if presented in the form 123-456-7890 remove the hyphens and use 1234567890\n\n### Hints for Dates\n    All dates should be in the form YYYY-MM-DD and must include the dashes (-)\n    Date ranges must be finite and must include a start and end date\n\n### Hints for limits\n    Requests to resource change_event must specify a LIMIT of less than or equal to 10000\n\n### Hints for conversions questions\n    https://developers.google.com/google-ads/api/docs/conversions/upload-summaries \n\n\n### Hints for all resources\n    To find out which specific fields (including compatible metrics and segments) you can select, filter by, or sort by for a given resource, you MUST use the `get_resource_metadata` tool.\n    Do not guess the fields. Use the tool to look them up.\n    Once you have the fields, ensure the whole field name is used (e.g., 'campaign.id', not just 'id'). Wildcards and partial fields are not allowed.\n\n### Valid resources\n    What follows is a list of valid resources that can be queried.\n    accessible_bidding_strategy\naccount_budget\naccount_budget_proposal\naccount_link\nad\nad_group\nad_group_ad\nad_group_ad_asset_combination_view\nad_group_ad_asset_view\nad_group_ad_label\nad_group_asset\nad_group_asset_set\nad_group_audience_view\nad_group_bid_modifier\nad_group_criterion\nad_group_criterion_customizer\nad_group_criterion_label\nad_group_criterion_simulation\nad_group_customizer\nad_group_label\nad_group_simulation\nad_parameter\nad_schedule_view\nage_range_view\nai_max_search_term_ad_combination_view\nandroid_privacy_shared_key_google_ad_group\nandroid_privacy_shared_key_google_campaign\nandroid_privacy_shared_key_google_network_type\napp_top_combination_view\napplied_incentive\nasset\nasset_field_type_view\nasset_group\nasset_group_asset\nasset_group_listing_group_filter\nasset_group_product_group_view\nasset_group_signal\nasset_group_top_combination_view\nasset_set\nasset_set_asset\nasset_set_type_view\naudience\nbatch_job\nbidding_data_exclusion\nbidding_seasonality_adjustment\nbidding_strategy\nbidding_strategy_simulation\nbilling_setup\ncall_view\ncampaign\ncampaign_aggregate_asset_view\ncampaign_asset\ncampaign_asset_set\ncampaign_audience_view\ncampaign_bid_modifier\ncampaign_budget\ncampaign_conversion_goal\ncampaign_criterion\ncampaign_customizer\ncampaign_draft\ncampaign_goal_config\ncampaign_group\ncampaign_label\ncampaign_search_term_insight\ncampaign_search_term_view\ncampaign_shared_set\ncampaign_simulation\ncarrier_constant\ncart_data_sales_view\nchange_event\nchange_status\nchannel_aggregate_asset_view\nclick_view\ncombined_audience\ncontent_criterion_view\nconversion_action\nconversion_custom_variable\nconversion_goal_campaign_config\nconversion_value_rule\nconversion_value_rule_set\ncurrency_constant\ncustom_audience\ncustom_conversion_goal\ncustom_interest\ncustomer\ncustomer_asset\ncustomer_asset_set\ncustomer_client\ncustomer_client_link\ncustomer_conversion_goal\ncustomer_customizer\ncustomer_label\ncustomer_manager_link\ncustomer_negative_criterion\ncustomer_search_term_insight\ncustomer_user_access\ncustomer_user_access_invitation\ncustomizer_attribute\ndata_link\ndetail_content_suitability_placement_view\ndetail_placement_view\ndetailed_demographic\ndisplay_keyword_view\ndistance_view\ndomain_category\ndynamic_search_ads_search_term_view\nexpanded_landing_page_view\nexperiment\nexperiment_arm\nfinal_url_expansion_asset_view\ngender_view\ngeo_target_constant\ngeographic_view\ngoal\ngroup_content_suitability_placement_view\ngroup_placement_view\nhotel_group_view\nhotel_performance_view\nhotel_reconciliation\nincome_range_view\nkeyword_plan\nkeyword_plan_ad_group\nkeyword_plan_ad_group_keyword\nkeyword_plan_campaign\nkeyword_plan_campaign_keyword\nkeyword_theme_constant\nkeyword_view\nlabel\nlanding_page_view\nlanguage_constant\nlead_form_submission_data\nlife_event\nlocal_services_employee\nlocal_services_lead\nlocal_services_lead_conversation\nlocal_services_verification_artifact\nlocation_interest_view\nlocation_view\nmanaged_placement_view\nmatched_location_interest_view\nmedia_file\nmobile_app_category_constant\nmobile_device_constant\nmulti_party_auth_review\noffline_conversion_upload_client_summary\noffline_conversion_upload_conversion_action_summary\noffline_user_data_job\noperating_system_version_constant\npaid_organic_search_term_view\nparental_status_view\nper_store_view\nperformance_max_placement_view\nproduct_category_constant\nproduct_group_view\nproduct_link\nproduct_link_invitation\nqualifying_question\nrecommendation\nrecommendation_subscription\nremarketing_action\nsearch_term_view\nshared_criterion\nshared_set\nshopping_performance_view\nshopping_product\nsmart_campaign_search_term_view\nsmart_campaign_setting\ntargeting_expansion_view\nthird_party_app_analytics_link\ntopic_constant\ntopic_view\ntravel_activity_group_view\ntravel_activity_performance_view\nuser_interest\nuser_list\nuser_list_customer_type\nuser_location_view\nvideo\nvideo_enhancement\nwebpage_view\nyou_tube_video_upload",
       "inputSchema": {
         "additionalProperties": false,
         "properties": {
           "conditions": {
             "default": [],
-            "description": "List of conditions to filter the data, combined using AND clauses",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
           "customer_id": {
-            "description": "The id of the customer",
             "type": "string"
           },
           "fields": {
-            "description": "The fields to fetch",
             "items": {
               "type": "string"
             },
@@ -102,19 +99,16 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "The maximum number of rows to return"
+            "default": null
           },
           "orderings": {
             "default": [],
-            "description": "How the data is ordered",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
           "resource": {
-            "description": "The resource to return fields from",
             "type": "string"
           }
         },
@@ -139,8 +133,7 @@
         "required": [
           "result"
         ],
-        "type": "object",
-        "x-fastmcp-wrap-result": true
+        "type": "object"
       }
     }
   ]

--- a/tests/tools/search_test.py
+++ b/tests/tools/search_test.py
@@ -97,6 +97,13 @@ class TestSearch(unittest.TestCase):
                     )
                     mock_log_error.assert_called_once()
 
+    def test_search_tool_description_omits_resources_removed_in_v25(self):
+        """Does not advertise resources absent from the v25 API contract."""
+        description = search._search_tool_description()
+
+        self.assertNotIn("\ncampaign_lifecycle_goal\n", description)
+        self.assertNotIn("\ncustomer_lifecycle_goal\n", description)
+
     @patch("ads_mcp.utils.get_googleads_service")
     def test_search_google_ads_exception(self, mock_get_service):
         """Tests that search handles GoogleAdsException and returns an error dict."""

--- a/tests/tools/search_test.py
+++ b/tests/tools/search_test.py
@@ -17,6 +17,8 @@
 import unittest
 from unittest.mock import MagicMock, patch, mock_open
 
+from fastmcp import Client
+
 from ads_mcp.tools import search
 
 
@@ -43,7 +45,7 @@ class TestSearch(unittest.TestCase):
         ]
 
         # Call search
-        results = search.search(
+        response = search.search(
             customer_id="1234567890",
             fields=["campaign.id", "campaign.name"],
             resource="campaign",
@@ -65,9 +67,9 @@ class TestSearch(unittest.TestCase):
         )
 
         # Verify results
-        self.assertEqual(len(results), 2)
-        self.assertEqual(results[0]["id"], 1)
-        self.assertEqual(results[1]["name"], "C2")
+        self.assertEqual(len(response["result"]), 2)
+        self.assertEqual(response["result"][0]["id"], 1)
+        self.assertEqual(response["result"][1]["name"], "C2")
 
     def test_search_tool_description(self):
         """Tests that the tool description is generated correctly."""
@@ -163,3 +165,38 @@ class TestSearch(unittest.TestCase):
             "Google Ads API Error: Invalid field name", str(context.exception)
         )
         self.assertIn("Request ID: req-123", str(context.exception))
+
+
+class TestSearchToolOutput(unittest.IsolatedAsyncioTestCase):
+    """Tests the MCP-visible search result contract."""
+
+    @patch("ads_mcp.utils.get_googleads_service")
+    async def test_empty_search_returns_content_and_structured_result(
+        self, mock_get_service
+    ):
+        """Keeps a zero-row success consumable by strict MCP clients."""
+        mock_service = MagicMock()
+        mock_service.search_stream.return_value = []
+        mock_get_service.return_value = mock_service
+
+        async with Client(search.search_mcp) as client:
+            result = await client.call_tool(
+                "search",
+                {
+                    "customer_id": "1234567890",
+                    "fields": ["change_event.resource_name"],
+                    "resource": "change_event",
+                    "conditions": [
+                        "change_event.change_date_time >= "
+                        "'2026-08-01 00:00:00'",
+                        "change_event.change_date_time <= "
+                        "'2026-08-12 15:36:51'",
+                    ],
+                    "orderings": ["change_event.change_date_time ASC"],
+                    "limit": 25,
+                },
+            )
+
+        self.assertFalse(result.is_error)
+        self.assertEqual(result.structured_content, {"result": []})
+        self.assertEqual(len(result.content), 1)

--- a/tests/tools/search_test.py
+++ b/tests/tools/search_test.py
@@ -97,12 +97,33 @@ class TestSearch(unittest.TestCase):
                     )
                     mock_log_error.assert_called_once()
 
-    def test_search_tool_description_omits_resources_removed_in_v25(self):
-        """Does not advertise resources absent from the v25 API contract."""
+    def test_search_tool_description_matches_v25_resource_delta(self):
+        """Advertises additions and omits removals from the v25 API contract."""
         description = search._search_tool_description()
+
+        for resource in (
+            "app_top_combination_view",
+            "cart_data_sales_view",
+            "multi_party_auth_review",
+            "video_enhancement",
+        ):
+            self.assertIn(f"\n{resource}\n", description)
 
         self.assertNotIn("\ncampaign_lifecycle_goal\n", description)
         self.assertNotIn("\ncustomer_lifecycle_goal\n", description)
+
+    def test_search_tool_description_links_to_v25_reference(self):
+        """Keeps the advertised field catalog aligned with the SDK contract."""
+        description = search._search_tool_description()
+
+        self.assertIn(
+            "https://developers.google.com/google-ads/api/fields/v25/overview",
+            description,
+        )
+        self.assertNotIn(
+            "https://developers.google.com/google-ads/api/fields/latest/overview",
+            description,
+        )
 
     @patch("ads_mcp.utils.get_googleads_service")
     def test_search_google_ads_exception(self, mock_get_service):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -15,10 +15,10 @@
 """Test cases for the utils module."""
 
 import unittest
-from google.ads.googleads.v24.enums.types.campaign_status import (
+from google.ads.googleads.v25.enums.types.campaign_status import (
     CampaignStatusEnum,
 )
-from google.ads.googleads.v24.common.types.metrics import Metrics
+from google.ads.googleads.v25.common.types.metrics import Metrics
 
 from ads_mcp import utils
 
@@ -34,6 +34,27 @@ class TestUtils(unittest.TestCase):
                 CampaignStatusEnum.CampaignStatus.ENABLED
             ),
             "ENABLED",
+        )
+
+    def test_get_googleads_service_uses_v25(self):
+        """Requests the reviewed v25 service contract explicitly."""
+        from unittest.mock import patch
+
+        with patch("ads_mcp.utils._get_googleads_client") as mock_client:
+            utils.get_googleads_service("CampaignService")
+
+        _, kwargs = mock_client.return_value.get_service.call_args
+        self.assertEqual(kwargs.get("version"), "v25")
+
+    def test_get_googleads_type_uses_v25(self):
+        """Requests the reviewed v25 message contract explicitly."""
+        from unittest.mock import patch
+
+        with patch("ads_mcp.utils._get_googleads_client") as mock_client:
+            utils.get_googleads_type("SearchGoogleAdsRequest")
+
+        mock_client.return_value.get_type.assert_called_once_with(
+            "SearchGoogleAdsRequest", version="v25"
         )
 
     def test_format_output_value_primitive(self):


### PR DESCRIPTION
## Summary

- pin the Google Ads client to 31.2.0 and reconcile API imports, discovery metadata, resources, and generated tool metadata with v25
- preserve the existing search query contract while returning an explicit `result` envelope
- add a regression proving a zero-row search produces both structured output and a content block for strict MCP clients

## Root cause

The search tool returned a bare list and relied on FastMCP's implicit result wrapping. A zero-row success produced no content block, which caused a strict MCP bridge to reject the response with `outputSchema defined but no structured output returned`. Returning an explicit typed result envelope keeps the public `structuredContent.result` shape and makes empty results serializable.

## Validation

- `uv run nox -s lint`
- `uv run python -m unittest discover --buffer -s tests -p '*_test.py'` — 41 passed
- `uv run python -m unittest tests.smoke.smoke_test` — 2 passed

All validation was credential-free and offline. No Google Ads API call or account mutation was performed while preparing this PR.
