### PR TITLE
Add automated package releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 
@@ -248,7 +248,7 @@ jobs:
           sha256sum dist/* > release-assets/SHA256SUMS
 
       - name: Upload validated distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-package-distributions-${{ github.run_id }}
           path: |
@@ -270,13 +270,13 @@ jobs:
       id-token: write
     steps:
       - name: Download validated distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions-${{ github.run_id }}
           path: artifact
 
       - name: Publish distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: artifact/dist/
           repository-url: https://test.pypi.org/legacy/
@@ -294,13 +294,13 @@ jobs:
       id-token: write
     steps:
       - name: Download validated distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions-${{ github.run_id }}
           path: artifact
 
       - name: Publish distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: artifact/dist/
 
@@ -315,7 +315,7 @@ jobs:
       contents: write
     steps:
       - name: Download validated release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions-${{ github.run_id }}
           path: artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,354 @@
+name: Release
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "ads_mcp/**"
+      - "MANIFEST.in"
+      - "pyproject.toml"
+      - "README.md"
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and validate distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Validate and prepare the package version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+          import tomllib
+
+          pyproject_path = pathlib.Path("pyproject.toml")
+          pyproject_text = pyproject_path.read_text(encoding="utf-8")
+          project = tomllib.loads(pyproject_text)["project"]
+          declared_version = project["version"]
+
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", declared_version):
+              raise SystemExit(
+                  "project.version must use the X.Y.Z form required by the "
+                  "release workflow"
+              )
+
+          event_name = os.environ["EVENT_NAME"]
+          package_version = declared_version
+
+          if event_name == "push":
+              expected_tag = f"v{declared_version}"
+              if os.environ["REF_NAME"] != expected_tag:
+                  raise SystemExit(
+                      f"tag {os.environ['REF_NAME']!r} does not match "
+                      f"project.version {declared_version!r}"
+                  )
+          elif event_name == "workflow_dispatch":
+              package_version = f"{declared_version}.dev{os.environ['RUN_ID']}"
+              updated_text, replacements = re.subn(
+                  r'(?m)^version = "[^"]+"$',
+                  f'version = "{package_version}"',
+                  pyproject_text,
+                  count=1,
+              )
+              if replacements != 1:
+                  raise SystemExit(
+                      "could not update exactly one project.version entry"
+                  )
+              pyproject_path.write_text(updated_text, encoding="utf-8")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"package-version={package_version}", file=output)
+          PY
+
+      - name: Validate the production tag
+        if: github.event_name == 'push'
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.package-version }}
+        run: |
+          if ! [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Production tags must use the exact vX.Y.Z form." >&2
+            exit 1
+          fi
+
+          if [ "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" != "tag" ]; then
+            echo "Production releases require an annotated tag." >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          tag_commit="$(git rev-list -n 1 "refs/tags/$GITHUB_REF_NAME")"
+          if ! git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main; then
+            echo "The tagged commit is not part of origin/main." >&2
+            exit 1
+          fi
+
+          python - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+
+          version = os.environ["PACKAGE_VERSION"]
+          url = f"https://pypi.org/pypi/google-ads-mcp/{version}/json"
+          request = urllib.request.Request(
+              url,
+              headers={"Accept": "application/json"},
+          )
+
+          try:
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  json.load(response)
+          except urllib.error.HTTPError as error:
+              if error.code == 404:
+                  raise SystemExit(0)
+              raise
+
+          raise SystemExit(
+              f"google-ads-mcp {version} already exists on PyPI; "
+              "published versions cannot be replaced"
+          )
+          PY
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Inspect distribution contents
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.package-version }}
+        run: |
+          python - <<'PY'
+          import email
+          import os
+          import pathlib
+          import tarfile
+          import zipfile
+
+          dist = pathlib.Path("dist")
+          wheels = list(dist.glob("*.whl"))
+          source_distributions = list(dist.glob("*.tar.gz"))
+          if len(wheels) != 1 or len(source_distributions) != 1:
+              raise SystemExit("expected exactly one wheel and one sdist")
+
+          version = os.environ["PACKAGE_VERSION"]
+          required_package_data = {
+              "ads_mcp/gaql_resources.txt",
+              "ads_mcp/tools_config.yaml",
+          }
+
+          with zipfile.ZipFile(wheels[0]) as archive:
+              names = set(archive.namelist())
+              missing = required_package_data - names
+              if missing:
+                  raise SystemExit(f"wheel is missing package data: {sorted(missing)}")
+
+              metadata_names = [
+                  name for name in names if name.endswith(".dist-info/METADATA")
+              ]
+              license_names = [
+                  name
+                  for name in names
+                  if ".dist-info/" in name and name.endswith("/LICENSE")
+              ]
+              if len(metadata_names) != 1 or not license_names:
+                  raise SystemExit("wheel is missing metadata or the license")
+
+              metadata = email.message_from_bytes(
+                  archive.read(metadata_names[0])
+              )
+              if metadata["Version"] != version:
+                  raise SystemExit(
+                      f"wheel version {metadata['Version']!r} does not match "
+                      f"{version!r}"
+                  )
+              if not metadata.get_payload().strip():
+                  raise SystemExit("wheel metadata is missing the README content")
+
+          with tarfile.open(source_distributions[0], "r:gz") as archive:
+              names = set(archive.getnames())
+
+          def sdist_contains(relative_path):
+              return any(
+                  name.partition("/")[2] == relative_path for name in names
+              )
+
+          required_sdist_files = {
+              "LICENSE",
+              "README.md",
+              *required_package_data,
+          }
+          missing = {
+              path for path in required_sdist_files if not sdist_contains(path)
+          }
+          if missing:
+              raise SystemExit(f"sdist is missing files: {sorted(missing)}")
+          PY
+
+      - name: Install and inspect the wheel
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.package-version }}
+        run: |
+          python -m venv .release-venv
+          .release-venv/bin/python -m pip install --no-deps dist/*.whl
+          .release-venv/bin/python - <<'PY'
+          import importlib.metadata
+          import importlib.resources
+          import os
+
+          import ads_mcp
+
+          installed_version = importlib.metadata.version("google-ads-mcp")
+          if installed_version != os.environ["PACKAGE_VERSION"]:
+              raise SystemExit(
+                  f"installed version {installed_version!r} does not match "
+                  f"{os.environ['PACKAGE_VERSION']!r}"
+              )
+
+          package_files = importlib.resources.files(ads_mcp)
+          for filename in ("gaql_resources.txt", "tools_config.yaml"):
+              if not package_files.joinpath(filename).is_file():
+                  raise SystemExit(f"installed wheel is missing {filename}")
+          PY
+
+      - name: Generate checksums
+        run: |
+          mkdir -p release-assets
+          sha256sum dist/* > release-assets/SHA256SUMS
+
+      - name: Upload validated distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions-${{ github.run_id }}
+          path: |
+            dist/*
+            release-assets/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    if: github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/google-ads-mcp
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download validated distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions-${{ github.run_id }}
+          path: artifact
+
+      - name: Publish distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: artifact/dist/
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/google-ads-mcp
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download validated distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions-${{ github.run_id }}
+          path: artifact
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: artifact/dist/
+
+  github-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+      - publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download validated release assets
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions-${{ github.run_id }}
+          path: artifact
+
+      - name: Create or resume the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            is_draft="$(
+              gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft
+            )"
+            if [ "$is_draft" != "true" ]; then
+              for asset in artifact/dist/* artifact/release-assets/SHA256SUMS; do
+                asset_name="$(basename "$asset")"
+                if ! gh release view "$GITHUB_REF_NAME" --json assets \
+                  --jq '.assets[].name' | grep -Fxq "$asset_name"; then
+                  echo "Published release is missing asset $asset_name." >&2
+                  exit 1
+                fi
+              done
+              exit 0
+            fi
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --draft \
+              --generate-notes \
+              --title "$GITHUB_REF_NAME" \
+              --verify-tag
+          fi
+
+          gh release upload "$GITHUB_REF_NAME" \
+            artifact/dist/* \
+            artifact/release-assets/SHA256SUMS \
+            --clobber
+          gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,3 +92,9 @@ branch named `awesome-feature-42` in this repo:
   }
 }
 ```
+
+## Publishing releases
+
+Release publication is restricted to project maintainers. See the
+[release guide](docs/releasing.md) for the PyPI and TestPyPI Trusted Publisher
+setup, release procedure, verification steps, and failure recovery.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Setup involves the following steps:
 
 [Install pipx](https://pipx.pypa.io/stable/#install-pipx).
 
+After a version has been published to PyPI, you can run that exact version
+instead of following the latest repository state:
+
+```shell
+pipx run --spec "google-ads-mcp==X.Y.Z" google-ads-mcp
+```
+
 ### Configure Developer Token
 
 Follow the instructions for [Obtaining a Developer Token](https://developers.google.com/google-ads/api/docs/get-started/dev-token).
@@ -410,3 +417,5 @@ How many active campaigns do I have for customer id 1234567890
 ## Contributing
 
 Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md).
+Project maintainers can find the Trusted Publishing and release procedure in
+the [release guide](docs/releasing.md).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,165 @@
+# Publishing releases
+
+This guide is for maintainers publishing `google-ads-mcp` to TestPyPI, PyPI,
+and GitHub Releases. The release workflow uses PyPI Trusted Publishing and
+short-lived OpenID Connect (OIDC) credentials. Do not create a `PYPI_TOKEN` or
+store a PyPI password in GitHub.
+
+The workflow file name and GitHub environment names are part of the trusted
+identity. If any of them changes, update the publisher configuration on the
+corresponding package index before attempting another publication.
+
+## Required access
+
+The maintainer performing the one-time setup needs:
+
+- repository administration access for `googleads/google-ads-mcp`;
+- Owner or Maintainer access to `google-ads-mcp` on PyPI; and
+- access to the corresponding project on TestPyPI, or permission to create a
+  pending publisher there.
+
+## Configure GitHub environments
+
+In the repository, open **Settings > Environments** and create these two
+environments:
+
+- `pypi` for production releases; and
+- `testpypi` for manual rehearsals.
+
+For `pypi`, configure at least one required reviewer and restrict deployments
+to tags matching `v*`. Do not allow administrators to bypass the production
+approval unless the repository's incident procedure explicitly requires it.
+Required reviewers are optional for `testpypi`, but the environment must still
+exist because its name is included in the OIDC identity.
+
+## Register the PyPI Trusted Publisher
+
+Follow PyPI's guide for [adding a publisher to an existing
+project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/):
+
+1. Sign in to PyPI and open **Your projects**.
+2. Select **Manage** for `google-ads-mcp`.
+3. Open **Publishing**.
+4. Add a GitHub Actions publisher with these exact values:
+
+   | Field | Value |
+   | --- | --- |
+   | Owner | `googleads` |
+   | Repository name | `google-ads-mcp` |
+   | Workflow name | `release.yml` |
+   | Environment name | `pypi` |
+
+After registration, the `publish-pypi` job can request a short-lived token.
+The job grants `id-token: write` only for that publication and uses PyPA's
+official [Trusted Publishing
+action](https://docs.pypi.org/trusted-publishers/using-a-publisher/).
+
+## Register the TestPyPI Trusted Publisher
+
+Sign in to [TestPyPI](https://test.pypi.org/) and register a separate GitHub
+Actions publisher. Use the same values as production except for the environment:
+
+| Field | Value |
+| --- | --- |
+| Owner | `googleads` |
+| Repository name | `google-ads-mcp` |
+| Workflow name | `release.yml` |
+| Environment name | `testpypi` |
+
+PyPI and TestPyPI are separate services. Registering the production publisher
+does not configure TestPyPI.
+
+## Rehearse a release on TestPyPI
+
+The manual workflow is available after `release.yml` has been merged into the
+repository's default branch.
+
+1. Open **Actions > Release > Run workflow**.
+2. Select the revision to test and start the workflow.
+3. Approve the `testpypi` environment if reviewers are configured.
+4. Wait for both **Build and validate distributions** and **Publish to
+   TestPyPI** to finish.
+5. Verify the new release on TestPyPI. Its version is derived from the declared
+   version and the unique workflow run ID, for example
+   `0.0.1.dev123456789`.
+6. Download the Actions artifact and verify that it contains one wheel, one
+   source distribution, and `SHA256SUMS`.
+
+The version change exists only in the runner workspace. It is never committed
+and the TestPyPI distributions are never reused for production. If a rehearsal
+must be repeated after it has published, start a new workflow run instead of
+rerunning the completed publication job; the new run receives a new version.
+
+## Publish a production release
+
+### Prepare the version
+
+1. Choose a new, unused `X.Y.Z` version that follows PEP 440.
+2. Create a pull request that changes only `project.version` in
+   `pyproject.toml`.
+3. Run and approve all required CI checks.
+4. Merge the version pull request into `main`.
+5. Confirm that the version does not already exist on PyPI.
+
+### Create the release tag
+
+From an up-to-date `main`, create and push an annotated tag:
+
+```shell
+git switch main
+git pull --ff-only
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Do not create the tag on an unmerged commit. Do not move or reuse it after it
+has been pushed.
+
+The workflow rejects a production tag unless all of these conditions hold:
+
+- the tag uses the exact `vX.Y.Z` format;
+- it is annotated;
+- `X.Y.Z` matches `project.version`;
+- the tagged commit belongs to `origin/main`; and
+- the version does not already exist on PyPI.
+
+### Approve and verify publication
+
+1. Approve the `pypi` environment deployment.
+2. Confirm that **Publish to PyPI** succeeds.
+3. Confirm that **Create GitHub Release** succeeds afterward.
+4. Verify the wheel and source distribution on PyPI.
+5. Verify that the GitHub Release contains those same files and
+   `SHA256SUMS`.
+6. Install the exact published version:
+
+   ```shell
+   pipx run --spec "google-ads-mcp==X.Y.Z" google-ads-mcp
+   ```
+
+7. Close the release issue only after at least one new production version is
+   available and installable.
+
+## Failure recovery
+
+- **Failure before PyPI publication:** correct the source through a pull
+  request, choose a new version, and create a new tag. Do not move a pushed
+  release tag.
+- **PyPI succeeded but GitHub Release failed:** use **Re-run failed jobs** so
+  the release job resumes its draft or verifies the already published assets.
+  Do not rerun the successful PyPI job.
+- **Defective published version:** yank it on PyPI when appropriate and publish
+  a corrected version. PyPI distributions cannot be overwritten.
+- **Interrupted TestPyPI rehearsal:** start a new manual run if the package was
+  already uploaded, because every uploaded version is immutable.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+| --- | --- | --- |
+| Trusted Publisher reports an invalid publisher | Owner, repository, workflow, or environment differs from the registered identity | Compare all four values character for character and update the index configuration if the workflow was renamed. |
+| The workflow cannot request an OIDC token | The publication job lacks `id-token: write` or is not using the registered environment | Keep `id-token: write` on the publication job and select the exact `pypi` or `testpypi` environment. |
+| Publication waits indefinitely | A protected environment is awaiting review | Ask an allowed reviewer to approve or reject the deployment in GitHub Actions. |
+| PyPI says a file or version already exists | The version was already uploaded | Never enable `skip-existing` for production. Choose a new version and tag. |
+| Production validation rejects the tag | The tag is lightweight, mismatches `project.version`, or is not on `main` | Merge the version change first, then create a new annotated tag from the merged commit. |
+| A TestPyPI rerun reports a duplicate version | The successful dispatch was rerun with the same run ID | Start a new manual workflow run to generate a new `.dev` version. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "google-ads-mcp"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

- Add a release workflow that builds and validates wheel and source distributions on pull requests
- Support manual TestPyPI rehearsals with unique development versions
- Publish annotated `vX.Y.Z` tags from `main` to PyPI through Trusted Publishing, then create a GitHub Release from the same artifacts
- Document the exact PyPI and TestPyPI Trusted Publisher configuration and maintainer release procedure
- Keep `project.version` at `0.0.1`; the first new production version will be selected in a follow-up PR

## Impact

This adds release infrastructure and maintainer documentation only. It does not change the server API or runtime behavior. Pull requests do not have OIDC publishing permissions and cannot publish packages.

## Validation

- Black formatting check: 38 files unchanged
- Test suite: 48 passed, 3 skipped
- Wheel and sdist built successfully
- `twine check` passed for both distributions
- Wheel installed and imported in an isolated environment
- Packaged YAML and text data verified in wheel and sdist
- Workflow validated with actionlint 1.7.12
- Pull-request workflow will be verified to build artifacts while skipping every publication job

Closes #107
