### PR TITLE
fix: let the golden generator run without google-genai

### DIFF
--- a/tests/smoke/generate_golden.py
+++ b/tests/smoke/generate_golden.py
@@ -16,11 +16,15 @@ import json
 import os
 import sys
 from tests.smoke import smoke_utils
-from google.genai import types
 
+# `google-genai` is only needed for the LLM token baselines, which are skipped
+# unless GEMINI_API_KEY is set. `llm_sender` imports it too, so one guard covers
+# both: without the package, the golden files still regenerate.
 try:
+    from google.genai import types
     from tests.smoke import llm_sender
 except ImportError:
+    types = None
     llm_sender = None
 
 


### PR DESCRIPTION
## Problem

`nox -s update_smoke_golden` fails for anyone who has not installed `google-genai`:

```
  File "tests/smoke/generate_golden.py", line 19, in <module>
    from google.genai import types
ModuleNotFoundError: No module named 'google.genai'
```

`google-genai` is not in `pyproject.toml` — not in `dependencies`, not in the `dev` extra. `nox -s llm_tests` installs it at run time, so a contributor following `CONTRIBUTING.md` (`pip install -e .[dev]`) does not have it. Regenerating the golden files needs nothing from the package: the LLM token baselines that do are already skipped unless `GEMINI_API_KEY` is set.

## Fix

`generate_golden.py` guarded its `llm_sender` import but not its `google.genai` import, which is the odd one out — `tests/smoke/llm_test.py` guards the same import correctly. Since `llm_sender` imports `google.genai` itself, one guard covers both, and `types` is only ever touched after the existing `llm_sender is None` early return.

## Verified

Same command, in the same environment, with `google-genai` uninstalled:

- before — `ModuleNotFoundError: No module named 'google.genai'`
- after — exit 0, both golden files written

`nox -s tests` (48 passed, 3 skipped) and `nox -s lint` are clean. No test accompanies this one: asserting that a module imports while an optional dependency is absent would need import-hook machinery larger than the fix itself.
