### PR TITLE
docs: document GOOGLE_ADS_LOGIN_CUSTOMER_ID in Cloud Run deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Make sure to set the required environment variables:
   periodic cleanup job for long-running deployments. Redis expires entries on
   its own.
 - `FASTMCP_HOST`: Set this to `0.0.0.0` to allow FastMCP to accept connections from all IP addresses.
+- `GOOGLE_ADS_LOGIN_CUSTOMER_ID`: Required if your access to the customer account is through a manager account. Set it to the customer ID of the manager account. See [Login Customer Id](#login-customer-id) above for details.
 
 ```shell
 gcloud run deploy google-ads-mcp \


### PR DESCRIPTION
## Summary
- Add `GOOGLE_ADS_LOGIN_CUSTOMER_ID` to the list of environment variables in the "Deployment to Google Cloud Platform" section, cross-referencing the existing "Login Customer Id" section.

Fixes #110

## Why
The Cloud Run deployment section lists env vars to set for `gcloud run deploy` but omits `GOOGLE_ADS_LOGIN_CUSTOMER_ID`. It's documented elsewhere (under "Login Customer Id"), but easy to miss when following the Cloud Run instructions in isolation. Deployments accessing a client account through a manager (MCC) account fail with `the manager's customer id must be set in the 'login-customer-id' header` until this variable is set.

## Test plan
- [x] Verified the new bullet renders correctly in README preview
- Docs-only change, no code/tests affected