### PR TITLE
feat: allow specifying login_customer_id per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,16 @@ The final file will look like this:
   }
   ```
 
+##### Accounts under several manager accounts
+
+`GOOGLE_ADS_LOGIN_CUSTOMER_ID` is fixed for the lifetime of the server process,
+so it can only name a single manager account. If you need to reach customers
+that are managed by different manager accounts from one server, for example a
+server shared by several agents or deployed to Cloud Run, pass the
+`login_customer_id` argument to the `search` tool instead. It takes precedence
+over the environment variable for that request only, and the environment
+variable is still used as the default when the argument is omitted.
+
 #### Other MCP clients (Claude Code, Cursor, VS Code, etc.)
 
 The `mcpServers` block format is the same across all MCP clients. Add the configuration shown above to the appropriate settings file for your client (e.g., `~/.claude/settings.json` for Claude Code, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for VS Code with Copilot).
@@ -344,7 +354,7 @@ Make sure to set the required environment variables:
   periodic cleanup job for long-running deployments. Redis expires entries on
   its own.
 - `FASTMCP_HOST`: Set this to `0.0.0.0` to allow FastMCP to accept connections from all IP addresses.
-- `GOOGLE_ADS_LOGIN_CUSTOMER_ID`: Required if your access to the customer account is through a manager account. Set it to the customer ID of the manager account. See [Login Customer Id](#login-customer-id) above for details.
+- `GOOGLE_ADS_LOGIN_CUSTOMER_ID`: Required if your access to the customer account is through a manager account. Set it to the customer ID of the manager account. See [Login Customer Id](#login-customer-id) above for details. If the deployment serves customers under more than one manager account, leave it unset and pass `login_customer_id` per request to the `search` tool instead.
 
 ```shell
 gcloud run deploy google-ads-mcp \

--- a/ads_mcp/tools/search.py
+++ b/ads_mcp/tools/search.py
@@ -33,6 +33,7 @@ def search(
     conditions: List[str] = [],
     orderings: List[str] = [],
     limit: int | None = None,
+    login_customer_id: str | None = None,
 ) -> List[Dict[str, Any]]:
     """Fetches data from the Google Ads API using the search method
 
@@ -43,10 +44,16 @@ def search(
         conditions: List of conditions to filter the data, combined using AND clauses
         orderings: How the data is ordered
         limit: The maximum number of rows to return
+        login_customer_id: The manager account that grants access to the
+          customer, as digits without punctuation. Only needed for customers
+          reached through a manager account. Defaults to the
+          GOOGLE_ADS_LOGIN_CUSTOMER_ID environment variable.
 
     """
 
-    ga_service = utils.get_googleads_service("GoogleAdsService")
+    ga_service = utils.get_googleads_service(
+        "GoogleAdsService", login_customer_id=login_customer_id
+    )
 
     query_parts = [f"SELECT {','.join(fields)} FROM {resource}"]
 
@@ -113,6 +120,14 @@ def _search_tool_description() -> str:
 ### Hint for customer_id
     should be a string of numbers without punctuation
     if presented in the form 123-456-7890 remove the hyphens and use 1234567890
+
+### Hints for login_customer_id
+    Use it when the server serves customers under several manager accounts,
+    since GOOGLE_ADS_LOGIN_CUSTOMER_ID can only name one of them.
+    The manager accounts available are returned by `list_accessible_customers`,
+    and the customers each one manages can be listed by querying the
+    `customer_client` resource with that manager account as both customer_id
+    and login_customer_id.
 
 ### Hints for Dates
     All dates should be in the form YYYY-MM-DD and must include the dashes (-)

--- a/ads_mcp/utils.py
+++ b/ads_mcp/utils.py
@@ -92,12 +92,30 @@ def _get_developer_token() -> str:
     return dev_token
 
 
-def _get_login_customer_id() -> str | None:
-    """Returns login customer id, if set, from the environment variable GOOGLE_ADS_LOGIN_CUSTOMER_ID."""
-    return os.environ.get("GOOGLE_ADS_LOGIN_CUSTOMER_ID")
+def _get_login_customer_id(
+    login_customer_id: str | None = None,
+) -> str | None:
+    """Returns the login customer id to use for a request, if any.
+
+    An explicit `login_customer_id` takes precedence over the
+    GOOGLE_ADS_LOGIN_CUSTOMER_ID environment variable. This lets a single
+    server instance serve accounts that are managed by different manager
+    accounts, which the environment variable alone can't express since it's
+    fixed for the lifetime of the process.
+
+    Args:
+        login_customer_id: The manager account id requested by the caller.
+
+    Returns:
+        The requested login customer id, the value of the environment
+        variable, or None if neither is set.
+    """
+    return login_customer_id or os.environ.get("GOOGLE_ADS_LOGIN_CUSTOMER_ID")
 
 
-def _get_googleads_client() -> GoogleAdsClient:
+def _get_googleads_client(
+    login_customer_id: str | None = None,
+) -> GoogleAdsClient:
     args = {
         "credentials": _create_credentials(),
         "developer_token": _get_developer_token(),
@@ -105,7 +123,7 @@ def _get_googleads_client() -> GoogleAdsClient:
     }
 
     # If the login-customer-id is not set, avoid setting None.
-    login_customer_id = _get_login_customer_id()
+    login_customer_id = _get_login_customer_id(login_customer_id)
 
     if login_customer_id:
         args["login_customer_id"] = login_customer_id
@@ -115,8 +133,10 @@ def _get_googleads_client() -> GoogleAdsClient:
     return client
 
 
-def get_googleads_service(serviceName: str) -> GoogleAdsServiceClient:
-    return _get_googleads_client().get_service(
+def get_googleads_service(
+    serviceName: str, login_customer_id: str | None = None
+) -> GoogleAdsServiceClient:
+    return _get_googleads_client(login_customer_id).get_service(
         serviceName, interceptors=[MCPHeaderInterceptor()]
     )
 
@@ -125,8 +145,8 @@ def get_googleads_type(typeName: str):
     return _get_googleads_client().get_type(typeName)
 
 
-def get_googleads_client():
-    return _get_googleads_client()
+def get_googleads_client(login_customer_id: str | None = None):
+    return _get_googleads_client(login_customer_id)
 
 
 def format_output_value(value: Any) -> Any:

--- a/tests/smoke/golden_tools_list.json
+++ b/tests/smoke/golden_tools_list.json
@@ -105,6 +105,18 @@
             "default": null,
             "description": "The maximum number of rows to return"
           },
+          "login_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The manager account that grants access to the\ncustomer, as digits without punctuation. Only needed for customers\nreached through a manager account. Defaults to the\nGOOGLE_ADS_LOGIN_CUSTOMER_ID environment variable."
+          },
           "orderings": {
             "default": [],
             "description": "How the data is ordered",

--- a/tests/tools/search_test.py
+++ b/tests/tools/search_test.py
@@ -69,6 +69,47 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(results[0]["id"], 1)
         self.assertEqual(results[1]["name"], "C2")
 
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_row")
+    def test_search_with_login_customer_id(
+        self, mock_format_row, mock_get_service
+    ):
+        """Tests that the login customer id is forwarded to the service."""
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+        mock_service.search_stream.return_value = []
+
+        search.search(
+            customer_id="1234567890",
+            fields=["campaign.id"],
+            resource="campaign",
+            login_customer_id="1111111111",
+        )
+
+        mock_get_service.assert_called_once_with(
+            "GoogleAdsService", login_customer_id="1111111111"
+        )
+
+    @patch("ads_mcp.utils.get_googleads_service")
+    @patch("ads_mcp.utils.format_output_row")
+    def test_search_without_login_customer_id(
+        self, mock_format_row, mock_get_service
+    ):
+        """Tests that no login customer id is forwarded when it's omitted."""
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+        mock_service.search_stream.return_value = []
+
+        search.search(
+            customer_id="1234567890",
+            fields=["campaign.id"],
+            resource="campaign",
+        )
+
+        mock_get_service.assert_called_once_with(
+            "GoogleAdsService", login_customer_id=None
+        )
+
     def test_search_tool_description(self):
         """Tests that the tool description is generated correctly."""
         # Mocking open as if the file exists

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -14,7 +14,10 @@
 
 """Test cases for the utils module."""
 
+import os
 import unittest
+from unittest.mock import patch
+
 from google.ads.googleads.v25.enums.types.campaign_status import (
     CampaignStatusEnum,
 )
@@ -72,6 +75,71 @@ class TestUtils(unittest.TestCase):
         fm = FieldMask(paths=["foo", "bar"])
         formatted = utils.format_output_value(fm)
         self.assertEqual(formatted, "foo,bar")
+
+    def test_get_login_customer_id_prefers_argument(self):
+        """Tests that an explicit login customer id wins over the env var."""
+        with patch.dict(
+            os.environ, {"GOOGLE_ADS_LOGIN_CUSTOMER_ID": "1111111111"}
+        ):
+            self.assertEqual(
+                utils._get_login_customer_id("2222222222"), "2222222222"
+            )
+
+    def test_get_login_customer_id_falls_back_to_environment(self):
+        """Tests that the env var is used when no id is passed in."""
+        with patch.dict(
+            os.environ, {"GOOGLE_ADS_LOGIN_CUSTOMER_ID": "1111111111"}
+        ):
+            self.assertEqual(utils._get_login_customer_id(), "1111111111")
+
+    def test_get_login_customer_id_unset(self):
+        """Tests that None is returned when neither source is set."""
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(utils._get_login_customer_id())
+
+    @patch("ads_mcp.utils._get_developer_token", return_value="token")
+    @patch("ads_mcp.utils._create_credentials", return_value="credentials")
+    @patch("ads_mcp.utils.GoogleAdsClient")
+    def test_get_googleads_client_with_login_customer_id(
+        self, mock_client, mock_credentials, mock_token
+    ):
+        """Tests that the requested login customer id reaches the client."""
+        with patch.dict(os.environ, {}, clear=True):
+            utils._get_googleads_client("2222222222")
+
+        mock_client.assert_called_once_with(
+            credentials="credentials",
+            developer_token="token",
+            use_proto_plus=True,
+            login_customer_id="2222222222",
+        )
+
+    @patch("ads_mcp.utils._get_developer_token", return_value="token")
+    @patch("ads_mcp.utils._create_credentials", return_value="credentials")
+    @patch("ads_mcp.utils.GoogleAdsClient")
+    def test_get_googleads_client_without_login_customer_id(
+        self, mock_client, mock_credentials, mock_token
+    ):
+        """Tests that no login customer id is set when none is available."""
+        with patch.dict(os.environ, {}, clear=True):
+            utils._get_googleads_client()
+
+        mock_client.assert_called_once_with(
+            credentials="credentials",
+            developer_token="token",
+            use_proto_plus=True,
+        )
+
+    @patch("ads_mcp.utils._get_googleads_client")
+    def test_get_googleads_service_passes_login_customer_id(
+        self, mock_get_client
+    ):
+        """Tests that get_googleads_service forwards the login customer id."""
+        utils.get_googleads_service(
+            "GoogleAdsService", login_customer_id="2222222222"
+        )
+
+        mock_get_client.assert_called_once_with("2222222222")
 
     def test_prevent_stdio_inheritance(self):
         """Tests that prevent_stdio_inheritance sets stdin to DEVNULL if not specified."""


### PR DESCRIPTION
## Problem

`GOOGLE_ADS_LOGIN_CUSTOMER_ID` is read once per process, so a server instance can
only ever act under a single manager account. That makes it impossible to serve
customers spread across several manager accounts from one instance, which is the
common case for a shared or Cloud Run deployment: a single agent working with
accounts under two MCCs has to be pointed at two separate servers.

## Solution

Add an optional `login_customer_id` argument to the `search` tool. It is threaded
down to `GoogleAdsClient` through `utils.get_googleads_service()` and takes
precedence over the environment variable, which remains the default when the
argument is omitted.

```python
def _get_login_customer_id(login_customer_id: str | None = None) -> str | None:
    return login_customer_id or os.environ.get("GOOGLE_ADS_LOGIN_CUSTOMER_ID")
```

## Backwards compatibility

None intended and none expected. The argument defaults to `None`, existing
deployments keep resolving the manager account from the environment variable, and
no existing call site changes behaviour.

## Scope

Only `search` gained the argument. `list_accessible_customers` returns the accounts
accessible to the authenticated user and `get_resource_metadata` queries
`GoogleAdsFieldService`; neither is scoped by a manager account, so an argument
there would be inert. Happy to widen the scope if you'd prefer the parameter on
every tool for consistency.

## Cost

The added parameter grows the `tools/list` payload by 325 characters (~80 tokens).
The parameter description is deliberately terse for that reason. No change to any
`llm_cases.json` baseline is required — the LLM test asserts tool selection, not
token counts.

## Testing

- Added unit tests covering argument-over-environment precedence, the environment
  fallback, neither being set, the resulting `GoogleAdsClient` kwargs, and the
  argument reaching `get_googleads_service` from the `search` tool.
- Regenerated `tests/smoke/golden_tools_list.json`.
- `nox -s lint`, `nox -s tests*` and `nox -s smoke_tests` pass.
- Verified end to end on Cloud Run: deployed with `GOOGLE_ADS_LOGIN_CUSTOMER_ID`
  unset, then queried customers under two different manager accounts within one
  session by passing `login_customer_id` per call. Both succeeded; the same call
  without the argument fails with a permission error, as expected.
